### PR TITLE
[TAO-2319][Feature] Add load_scored_annotations and scored-annotation tests

### DIFF
--- a/nvidia_tao_ds/core/utils/dataset_loading.py
+++ b/nvidia_tao_ds/core/utils/dataset_loading.py
@@ -6,9 +6,12 @@
 from __future__ import annotations
 
 import json
+import logging
 from enum import Enum
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
+
+_log = logging.getLogger(__name__)
 
 
 class AnnotationFormat(str, Enum):
@@ -39,7 +42,30 @@ def load_annotations(path: str, fmt: AnnotationFormat) -> Tuple[dict, dict, dict
     return _FORMAT_LOADERS[fmt](path)
 
 
-def _load_kitti(label_dir: str) -> Tuple[dict, dict, dict, dict]:
+def load_scored_annotations(path: str, fmt: AnnotationFormat) -> Tuple[dict, dict, dict, dict]:
+    """Like :func:`load_annotations` but box tuples include a confidence score.
+
+    Identical to :func:`load_annotations` in every respect except that the
+    ``*_to_boxes`` maps contain ``(class_name, [x, y, w, h], score_or_None)``
+    3-tuples instead of 2-tuples. ``score_or_None`` is ``None`` when no score
+    is present in the source (e.g. ground-truth KITTI/COCO files).
+
+    Args:
+        path: Path to a KITTI label directory or a COCO ``.json`` file.
+        fmt: The annotation format, declared explicitly by the caller.
+
+    Returns:
+        A ``(fp_to_classes, bn_to_classes, fp_to_boxes, bn_to_boxes)`` tuple
+        where ``*_to_boxes`` values are lists of ``(class_name, [x, y, w, h], score_or_None)``.
+
+    Raises:
+        FileNotFoundError: if ``path`` does not exist.
+        ValueError: if a COCO file is invalid.
+    """
+    return _FORMAT_LOADERS[fmt](path, with_scores=True)
+
+
+def _load_kitti(label_dir: str, with_scores: bool = False) -> Tuple[dict, dict, dict, dict]:
     """
     Parse a KITTI label directory. Each .txt file corresponds to one image
     (filename stem matches image basename stem). Each line format:
@@ -49,6 +75,9 @@ def _load_kitti(label_dir: str) -> Tuple[dict, dict, dict, dict]:
     Since KITTI has no absolute image paths, only basename (stem) matching is
     populated; fp_to_* dicts are always empty. Malformed lines within a label file
     are skipped; an empty directory (no ``.txt`` files) raises.
+
+    When ``with_scores`` is True, box entries are ``(class, bbox, score_or_None)``
+    3-tuples; otherwise they are ``(class, bbox)`` 2-tuples.
 
     Raises:
         FileNotFoundError: If the directory contains no ``.txt`` label files.
@@ -80,17 +109,33 @@ def _load_kitti(label_dir: str) -> Tuple[dict, dict, dict, dict]:
                     continue
                 bbox = [x1, y1, x2 - x1, y2 - y1]  # convert to [x, y, w, h]
                 bn_to_classes.setdefault(bn, set()).add(cat_name)
-                bn_to_boxes.setdefault(bn, []).append((cat_name, bbox))
+                if with_scores:
+                    score: Optional[float] = None
+                    if len(parts) >= 16:
+                        try:
+                            score = float(parts[15])
+                        except ValueError:
+                            _log.warning(
+                                "Malformed score field %r in %s — treating as unscored",
+                                parts[15], txt_file,
+                            )
+                    bn_to_boxes.setdefault(bn, []).append((cat_name, bbox, score))
+                else:
+                    bn_to_boxes.setdefault(bn, []).append((cat_name, bbox))
 
     return {}, bn_to_classes, {}, bn_to_boxes
 
 
-def _load_coco(coco_file: str) -> Tuple[dict, dict, dict, dict]:
+def _load_coco(coco_file: str, with_scores: bool = False) -> Tuple[dict, dict, dict, dict]:
     """
     Parse a COCO JSON file in one pass.
     Returns (fp_to_classes, bn_to_classes, fp_to_boxes, bn_to_boxes) where:
     - fp/bn_to_classes: path → set of class names
     - fp/bn_to_boxes:   path → list of (class_name, [x, y, w, h])
+
+    When ``with_scores`` is True, box entries are ``(class, bbox, score_or_None)``
+    3-tuples; ``score_or_None`` is the annotation's ``"score"`` field or ``None``
+    when absent (standard for ground-truth COCO files).
 
     Raises ValueError if the file is not a valid JSON object or is missing the
     'images' / 'annotations' keys (i.e. is not a COCO annotation file).
@@ -137,8 +182,22 @@ def _load_coco(coco_file: str) -> Tuple[dict, dict, dict, dict]:
         bn_to_fps.setdefault(bn, set()).add(fp)
         bbox = ann.get("bbox")
         if bbox and len(bbox) == 4:
-            fp_to_boxes.setdefault(fp, []).append((cat_name, bbox))
-            bn_to_boxes.setdefault(bn, []).append((cat_name, bbox))
+            if with_scores:
+                raw_score = ann.get("score")
+                score: Optional[float] = None
+                if raw_score is not None:
+                    try:
+                        score = float(raw_score)
+                    except (TypeError, ValueError):
+                        _log.warning(
+                            "Invalid score value %r in COCO file — treating as unscored",
+                            raw_score,
+                        )
+                entry = (cat_name, bbox, score)
+            else:
+                entry = (cat_name, bbox)
+            fp_to_boxes.setdefault(fp, []).append(entry)
+            bn_to_boxes.setdefault(bn, []).append(entry)
 
     # A basename shared by multiple distinct image paths is ambiguous — its
     # basename-keyed annotations merge unrelated images. Drop those from the

--- a/tests/test_dataset_loading.py
+++ b/tests/test_dataset_loading.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for nvidia_tao_ds/core/utils/dataset_loading.py (COCO annotation loading).
+
+CPU-only: exercises the pure-Python COCO parser, no RAPIDS/GPU required.
+"""
+
+import json
+from pathlib import Path
+
+from nvidia_tao_ds.core.utils.dataset_loading import _load_coco
+
+
+def _write_coco(path, images, categories, annotations):
+    """Write a minimal COCO JSON.
+
+    images: list of (id, file_name); categories: list of (id, name);
+    annotations: list of (image_id, category_id, [x, y, w, h]).
+    """
+    coco = {
+        "images": [{"id": i, "file_name": fn} for i, fn in images],
+        "categories": [{"id": i, "name": n} for i, n in categories],
+        "annotations": [
+            {"id": k, "image_id": im, "category_id": c, "bbox": b}
+            for k, (im, c, b) in enumerate(annotations)
+        ],
+    }
+    Path(path).write_text(json.dumps(coco), encoding="utf-8")
+    return str(path)
+
+
+def test_load_coco_drops_ambiguous_basename(tmp_path):
+    """Two images sharing a basename don't merge — the basename fallback drops the collision."""
+    coco = _write_coco(
+        tmp_path / "ann.json",
+        images=[(0, "dirA/frame.png"), (1, "dirB/frame.png")],
+        categories=[(1, "person"), (2, "car")],
+        annotations=[(0, 1, [0, 0, 1, 1]), (1, 2, [0, 0, 1, 1])],
+    )
+    fp_to_classes, bn_to_classes, _, _ = _load_coco(coco)
+
+    # Full-path lookups stay precise...
+    assert fp_to_classes["dirA/frame.png"] == {"person"}
+    assert fp_to_classes["dirB/frame.png"] == {"car"}
+    # ...but the ambiguous basename is dropped, so it can't return {person, car}.
+    assert "frame.png" not in bn_to_classes
+
+
+def test_load_coco_keeps_unambiguous_basename(tmp_path):
+    """A basename owned by a single image is retained for fallback lookup."""
+    coco = _write_coco(
+        tmp_path / "ann.json",
+        images=[(0, "only/cat.png")], categories=[(1, "dog")],
+        annotations=[(0, 1, [0, 0, 1, 1])],
+    )
+    _, bn_to_classes, _, _ = _load_coco(coco)
+    assert bn_to_classes["cat.png"] == {"dog"}

--- a/tests/test_dataset_loading.py
+++ b/tests/test_dataset_loading.py
@@ -1,26 +1,22 @@
-# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
-"""Tests for nvidia_tao_ds/core/utils/dataset_loading.py (COCO annotation loading).
+"""Tests for nvidia_tao_ds/core/utils/dataset_loading.py.
 
-CPU-only: exercises the pure-Python COCO parser, no RAPIDS/GPU required.
+CPU-only: exercises the pure-Python KITTI/COCO parsers, no RAPIDS/GPU required.
 """
 
 import json
 from pathlib import Path
 
-from nvidia_tao_ds.core.utils.dataset_loading import _load_coco
+import pytest
+
+from nvidia_tao_ds.core.utils.dataset_loading import (
+    AnnotationFormat,
+    _load_coco,
+    load_annotations,
+    load_scored_annotations,
+)
 
 
 def _write_coco(path, images, categories, annotations):
@@ -67,3 +63,70 @@ def test_load_coco_keeps_unambiguous_basename(tmp_path):
     )
     _, bn_to_classes, _, _ = _load_coco(coco)
     assert bn_to_classes["cat.png"] == {"dog"}
+
+
+# ---------------------------------------------------------------------------
+# load_scored_annotations — KITTI
+# ---------------------------------------------------------------------------
+
+_KITTI_LINE = "Car 0.00 0 -1.57 614.24 181.78 727.31 284.77 1.57 1.73 4.15 1.00 1.75 8.20 -1.56"
+
+
+@pytest.fixture()
+def kitti_scored(tmp_path):
+    d = tmp_path / "labels"
+    d.mkdir()
+    (d / "img_a.txt").write_text(_KITTI_LINE + " 0.92\n")
+    (d / "img_b.txt").write_text(_KITTI_LINE + "\n")  # no score
+    return str(d)
+
+
+def test_load_scored_kitti_returns_three_tuples(kitti_scored):
+    _, _, _, bn = load_scored_annotations(kitti_scored, AnnotationFormat.KITTI)
+    assert all(len(b) == 3 for b in bn["img_a"])
+
+
+def test_load_scored_kitti_score_parsed(kitti_scored):
+    _, _, _, bn = load_scored_annotations(kitti_scored, AnnotationFormat.KITTI)
+    assert bn["img_a"][0][2] == pytest.approx(0.92)
+
+
+def test_load_scored_kitti_missing_score_is_none(kitti_scored):
+    _, _, _, bn = load_scored_annotations(kitti_scored, AnnotationFormat.KITTI)
+    assert bn["img_b"][0][2] is None
+
+
+def test_load_annotations_ignores_kitti_score(kitti_scored):
+    """load_annotations must still return 2-tuples even when the source has scores."""
+    _, _, _, bn = load_annotations(kitti_scored, AnnotationFormat.KITTI)
+    assert all(len(b) == 2 for b in bn["img_a"])
+
+
+# ---------------------------------------------------------------------------
+# load_scored_annotations — COCO
+# ---------------------------------------------------------------------------
+
+def test_load_scored_coco_score_populated(tmp_path):
+    preds_path = tmp_path / "preds.json"
+    _write_coco(
+        preds_path,
+        images=[(1, "img.jpg")], categories=[(1, "car")],
+        annotations=[(1, 1, [0, 0, 10, 10])],
+    )
+    # Manually inject score into annotation
+    data = json.loads(preds_path.read_text())
+    data["annotations"][0]["score"] = 0.85
+    preds_path.write_text(json.dumps(data))
+
+    _, _, fp, _ = load_scored_annotations(str(preds_path), AnnotationFormat.COCO)
+    assert fp["img.jpg"][0][2] == pytest.approx(0.85)
+
+
+def test_load_scored_coco_missing_score_is_none(tmp_path):
+    coco = _write_coco(
+        tmp_path / "gt.json",
+        images=[(1, "img.jpg")], categories=[(1, "car")],
+        annotations=[(1, 1, [0, 0, 10, 10])],
+    )
+    _, _, fp, _ = load_scored_annotations(coco, AnnotationFormat.COCO)
+    assert fp["img.jpg"][0][2] is None


### PR DESCRIPTION
**Stack:** TAO-2319 slice 1/4 — targets `main`.

## Summary

- Extend `_load_kitti` and `_load_coco` with scored-annotation support: `load_scored_annotations(path, fmt)` returns `(class, bbox, score_or_None)` 3-tuples; `load_annotations` unchanged.
- COCO score coerced via `float()` with `try/except (TypeError, ValueError)` fallback to `None` and a warning.
- KITTI malformed score field logs a warning instead of silently ignoring.
- 8 CPU-only tests.

## Test plan
- [ ] `python -m pytest tests/test_dataset_loading.py -v`