### PR TITLE
[TAO-2319][Bugfix] Correct kpi.py FN sentinel and voc_ap argument order

### DIFF
--- a/nvidia_tao_ds/data_analytics/utils/kpi.py
+++ b/nvidia_tao_ds/data_analytics/utils/kpi.py
@@ -336,7 +336,7 @@ def evaluate(gt_data_obj, pred_data_obj, cat_map, matching_iou_threshold=0.5, co
         TP, FP, FN, TN, precision, recall, accuracy, prec, rec = evaluate_class(per_img_match, gt_list, pred_list, conf_threshold)
 
         # Calculate Pascal VOC style AP
-        ap = voc_ap(np.array(prec), np.array(rec), "sample", num_recall_points)
+        ap = voc_ap(np.array(rec), np.array(prec), "sample", num_recall_points)
 
         stats.append({
             'class_name': class_name,

--- a/nvidia_tao_ds/data_analytics/utils/kpi.py
+++ b/nvidia_tao_ds/data_analytics/utils/kpi.py
@@ -173,7 +173,7 @@ def _per_img_match(x, n_classes, sorting_algorithm, matching_iou_threshold, min_
                     non_match_count += 1
 
         T[idx].extend([1] * non_match_count)
-        P[idx].extend([0.0] * non_match_count)
+        P[idx].extend([-1.0] * non_match_count)
 
     return (T, P, TN)
 


### PR DESCRIPTION
## Summary

- **Bug**: `_per_img_match` in `kpi.py` encodes undetected GT boxes with `P[idx].extend([0.0] * non_match_count)`. At `conf_threshold=0.0` (the default), `0.0 >= 0.0` is `True`, so every unmatched GT is counted as a **TP instead of FN**. This makes `TP == GT count`, `FN == 0`, and `recall == 1.0` always.
- **Fix**: Change the sentinel from `0.0` to `-1.0`. Since `-1.0` is below every valid confidence score, `p < conf_threshold` is always `True` for unmatched GTs regardless of threshold.
- **Why not change `>=` to `>`**: That would fix the zero case but would wrongly drop legitimate detections whose confidence exactly equals `conf_threshold`.

## Root cause (one line)

```python
# Before (line 176) — collides with TP branch at conf_threshold=0.0
P[idx].extend([0.0] * non_match_count)

# After — -1.0 is below every valid confidence, FN branch always taken
P[idx].extend([-1.0] * non_match_count)
```

## Test plan

- [ ] Verify `evaluate_class` with `conf_threshold=0.0`, 1 GT, 0 predictions → `FN=1`, `TP=0`, `recall=0.0`
- [ ] Verify existing behaviour unchanged at `conf_threshold=0.5`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)