### PR TITLE
[TAO-2523][Docs] Refresh developer docs: codebase tour, deeper architecture, GitHub-era CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ agents, and container power users.
 | `runner/tao_ds.py` | Host-side Docker launcher used by the `tao_ds` shell function from `scripts/envsetup.sh`. |
 | `docker/` | Base development image Dockerfile, requirements, build script, and digest manifest. |
 | `release/` | Python package metadata plus release-container build scripts. |
-| `ci/` and `.gitlab-ci.yml` | Static-test helpers and merge-request pipeline wiring. |
+| `.github/workflows/` and `.pre-commit-config.yaml` | Pull-request checks: lint, license headers, DCO, README drift, and secret scan. |
 | `tests/` | Unit and integration-style tests for conversion, analytics, auto-label, mining, and config behavior. |
 | `tao-core/`, `tao-pytorch/` | In-repo submodules used by local development and container builds. |
 
@@ -115,11 +115,11 @@ subtasks are discovered from each command package's `scripts/` directory.
 
 ### Base Image Source
 
-`runner/tao_ds.py` and `ci/utils.py` resolve the immutable base image
+`runner/tao_ds.py` resolves the immutable base image
 (`nvstaging/tao/data_services_base_image`) from `docker/manifest.json`, choosing the architecture-specific
 digest for the host. The pinned digests are intentionally not duplicated here — they
-live in `docker/manifest.json` (and the CI / Jenkins / release files), and a static CI
-check (`ci/run_static_tests.py`) verifies those digest references stay in sync.
+live in `docker/manifest.json` and `release/docker/Dockerfile.release`; update both
+together when the base image is rebuilt.
 <!-- END GENERATED: supported-commands -->
 
 ## Container Builds

--- a/docs/agent_onboarding.md
+++ b/docs/agent_onboarding.md
@@ -10,7 +10,8 @@ full directory walk, read the [Codebase tour](codebase_tour.md).
 image from `docker/manifest.json`, mounts this source tree at `/workspace`, and
 executes any command passed after `--`.
 
-Inside the container, `setup.py` installs one console script per service:
+Inside the container, `setup.py` installs one console script per function
+(refer to Terminology in [Architecture](architecture.md)):
 `annotations`, `augmentation`, `analytics`, `auto_label`, `image`,
 `gap_analysis`, `tmm`, and `embedding`. All of them use the shared command dispatcher in
 `nvidia_tao_ds/core/entrypoint/entrypoint.py` to discover subtasks from
@@ -20,9 +21,9 @@ a fresh Python subprocess under Hydra.
 ```text
 console command (setup.py)
   -> nvidia_tao_ds/core/entrypoint/entrypoint.py
-  -> nvidia_tao_ds/<service>/scripts/<subtask>.py   (fresh subprocess)
-  -> Hydra spec validated against nvidia_tao_ds/config/<service>/
-  -> service logic (conversion, DALI, model inference, mining, ...)
+  -> nvidia_tao_ds/<function>/scripts/<subtask>.py   (fresh subprocess)
+  -> Hydra spec validated against nvidia_tao_ds/config/<function>/
+  -> function logic (conversion, DALI, model inference, mining, ...)
 ```
 
 ## First Pass
@@ -58,10 +59,10 @@ git submodule update --init
 | Which package commands exist? | `setup.py` `console_scripts` |
 | Which host launcher flags exist? | `runner/tao_ds.py` `parse_cli_args` |
 | Which base image is pulled? | `docker/manifest.json` |
-| Which subtasks exist? | `nvidia_tao_ds/<service>/scripts/*.py` |
-| Which example specs exist? | `nvidia_tao_ds/<service>/experiment_specs/*.yaml` |
+| Which subtasks exist? | `nvidia_tao_ds/<function>/scripts/*.py` |
+| Which example specs exist? | `nvidia_tao_ds/<function>/experiment_specs/*.yaml` |
 | Which specification template does a subtask load? | The script's `@hydra_runner(config_name=...)`, not the subtask name |
-| Which dataclass schema is used? | `nvidia_tao_ds/config/<service>/...` (`analytics` is the configuration package for `data_analytics/`) |
+| Which dataclass schema is used? | `nvidia_tao_ds/config/<function>/...` (`analytics` is the configuration package for `data_analytics/`) |
 | Which static tests run in CI? | `.pre-commit-config.yaml` via `.github/workflows/static-tests.yml` |
 | Which README content is generated? | `tools/update_readme_supported_commands.py` |
 

--- a/docs/agent_onboarding.md
+++ b/docs/agent_onboarding.md
@@ -1,6 +1,29 @@
 # Agent Onboarding
 
-Use this guide to get oriented without disturbing a user-owned worktree.
+Use this guide to get oriented without disturbing a user-owned worktree. For a
+full directory walk, read the [Codebase tour](codebase_tour.md).
+
+## Mental Model
+
+`scripts/envsetup.sh` sets `NV_TAO_DS_TOP` and defines a shell function named
+`tao_ds`. That function runs `runner/tao_ds.py`, which starts the base Docker
+image from `docker/manifest.json`, mounts this source tree at `/workspace`, and
+executes any command passed after `--`.
+
+Inside the container, `setup.py` installs one console script per service:
+`annotations`, `augmentation`, `analytics`, `auto_label`, `image`,
+`gap_analysis`, `tmm`, and `embedding`. All of them use the shared launcher in
+`nvidia_tao_ds/core/entrypoint/entrypoint.py` to discover subtasks from
+`scripts/`, require `-e/--experiment_spec_file`, and run the selected script as
+a fresh Python subprocess under Hydra.
+
+```text
+console command (setup.py)
+  -> nvidia_tao_ds/core/entrypoint/entrypoint.py
+  -> nvidia_tao_ds/<service>/scripts/<subtask>.py   (fresh subprocess)
+  -> Hydra spec validated against nvidia_tao_ds/config/<service>/
+  -> service logic (conversion, DALI, model inference, mining, ...)
+```
 
 ## First Pass
 
@@ -12,54 +35,53 @@ git -c filter.lfs.process= -c filter.lfs.required=false status --short --branch
 git remote -v
 find . -maxdepth 2 -type d
 sed -n '1,220p' README.md
-sed -n '1,220p' .gitlab-ci.yml
 rg -n "console_scripts|entry_points" setup.py
 rg -n "ArgumentParser|manifest.json|--gpus|--tag|--run_as_user" runner scripts docker release
 rg -n "hydra_runner|default_specs|get_subtasks|entrypoint|console_scripts" nvidia_tao_ds setup.py
-rg -n "pytest|run_static|pre-commit|flake8|pylint" .gitlab-ci.yml ci tests
+ls .github/workflows/
+sed -n '1,80p' .pre-commit-config.yaml
 ```
 
-Treat `tao-core/` and `tao-pytorch/` as submodules or vendored source in this
-checkout. They may be dirty for reasons unrelated to your task. Do not reset,
-update, or rewrite them unless the task explicitly requires it.
+Treat `tao-core/` and `tao-pytorch/` as submodules in this checkout. They may
+be dirty for reasons unrelated to your task. Do not reset, update, or rewrite
+them unless the task explicitly requires it. Initialize them before running
+anything:
 
-## Mental Model
-
-`scripts/envsetup.sh` sets `NV_TAO_DS_TOP` and defines a shell function named
-`tao_ds`. That function runs `runner/tao_ds.py`, which starts the base Docker
-image from `docker/manifest.json`, mounts this source tree at `/workspace`, and
-executes any command passed after `--`.
-
-Inside the container, `setup.py` installs package console scripts such as
-`annotations`, `augmentation`, `analytics`, `auto_label`, `image`,
-`gap_analysis`, `tmm`, and `embedding`. Most commands use the shared launcher in
-`nvidia_tao_ds/core/entrypoint/entrypoint.py` to discover subtasks from
-`scripts/`, require `-e/--experiment_spec_file`, and pass the selected YAML to
-Hydra. Mining and RCCA commands use thinner dispatchers that forward Hydra
-arguments directly to their selected script.
+```sh
+git submodule update --init
+```
 
 ## Source Truths
 
-| Question | Source Of Truth |
+| Question | Source of truth |
 | :--- | :--- |
 | Which package commands exist? | `setup.py` `console_scripts` |
 | Which host launcher flags exist? | `runner/tao_ds.py` `parse_cli_args` |
 | Which base image is pulled? | `docker/manifest.json` |
-| Which subtasks exist? | `nvidia_tao_ds/$DOMAIN/scripts/*.py` |
-| Which example specs exist? | `nvidia_tao_ds/$DOMAIN/experiment_specs/*.yaml` |
-| Which dataclass schema is used? | `nvidia_tao_ds/config/$DOMAIN/...` |
-| Which static tests run in GitLab? | `.gitlab-ci.yml` and `ci/run_static_tests.py` |
+| Which subtasks exist? | `nvidia_tao_ds/<service>/scripts/*.py` |
+| Which example specs exist? | `nvidia_tao_ds/<service>/experiment_specs/*.yaml` |
+| Which specification template does a subtask load? | The script's `@hydra_runner(config_name=...)`, not the subtask name |
+| Which dataclass schema is used? | `nvidia_tao_ds/config/<service>/...` (`analytics` is the configuration package for `data_analytics/`) |
+| Which static tests run in CI? | `.pre-commit-config.yaml` via `.github/workflows/static-tests.yml` |
 | Which README content is generated? | `tools/update_readme_supported_commands.py` |
+
+## Common Agent Questions
+
+| Question | Where to look |
+| :--- | :--- |
+| Where is the shared launcher behavior (GPU handling, subprocess, telemetry)? | `nvidia_tao_ds/core/entrypoint/entrypoint.py` |
+| Why does a CPU command need a GPU host? | The launcher calls `nvidia-smi` unconditionally |
+| Why does my new subtask ignore `num_gpus`? | Multi-GPU is keyed on the literal subtask name `generate` |
+| Why is there no `status.json` for a subtask? | The script lacks `@monitor_status`; refer to the coverage list in the [Codebase tour](codebase_tour.md) |
+| Which model does auto-label use? | `auto_label/scripts/generate.py` dispatches on `cfg.autolabel_type` |
+| Where do LLM/VLM calls happen? | `nvidia_tao_ds/core/llm_clients/` |
+| How does the API relate to the CLI? | Dev-mode Flask app versus the tao-core microservice; refer to [Architecture](architecture.md) |
 
 ## Worktree Safety
 
-Before editing, capture the status and decide which files you own. The docs
-rollout normally touches `README.md`, `docs/`, `tools/update_readme_supported_commands.py`,
-`.pre-commit-config.yaml`, and `.gitlab-ci.yml`.
-
-Avoid broad cleanup. Do not remove user-created tests, local examples, cache
-directories outside your own generated outputs, or submodule changes unless the
-user asks.
+Before editing, capture the status and decide which files you own. Avoid broad
+cleanup. Do not remove user-created tests, local examples, cache directories
+outside your own generated outputs, or submodule changes unless the user asks.
 
 ## Targeted Checks
 
@@ -68,10 +90,13 @@ For documentation and generated README changes:
 ```sh
 python tools/update_readme_supported_commands.py --check
 python -m py_compile tools/update_readme_supported_commands.py
-git diff --check -- README.md docs/*.md docs/assets/*.svg tools/*.py .pre-commit-config.yaml .gitlab-ci.yml
+git diff --check -- README.md docs/*.md docs/assets/*.svg tools/*.py .pre-commit-config.yaml
 rg -n "TBD|PLACEHOLDER|example\\.com" README.md docs
 ```
 
-For source-adjacent command or config changes, add focused pytest runs from
-[testing_and_debugging.md](testing_and_debugging.md). GPU, Docker, private
-checkpoint, NGC, and full dataset tests are usually outside a docs-only change.
+For source-adjacent command or configuration changes, run the same static
+checks CI runs (`pre-commit run` on the changed files) and add focused pytest
+runs from [Testing and debugging](testing_and_debugging.md). GPU, Docker, private
+checkpoint, NGC, and full dataset tests are usually outside a documentation-only change.
+
+All commits need a DCO sign-off (`git commit -s`); CI enforces it.

--- a/docs/agent_onboarding.md
+++ b/docs/agent_onboarding.md
@@ -12,7 +12,7 @@ executes any command passed after `--`.
 
 Inside the container, `setup.py` installs one console script per service:
 `annotations`, `augmentation`, `analytics`, `auto_label`, `image`,
-`gap_analysis`, `tmm`, and `embedding`. All of them use the shared launcher in
+`gap_analysis`, `tmm`, and `embedding`. All of them use the shared command dispatcher in
 `nvidia_tao_ds/core/entrypoint/entrypoint.py` to discover subtasks from
 `scripts/`, require `-e/--experiment_spec_file`, and run the selected script as
 a fresh Python subprocess under Hydra.
@@ -69,8 +69,8 @@ git submodule update --init
 
 | Question | Where to look |
 | :--- | :--- |
-| Where is the shared launcher behavior (GPU handling, subprocess, telemetry)? | `nvidia_tao_ds/core/entrypoint/entrypoint.py` |
-| Why does a CPU command need a GPU host? | The launcher calls `nvidia-smi` unconditionally |
+| Where is the shared dispatcher behavior (GPU handling, subprocess, telemetry)? | `nvidia_tao_ds/core/entrypoint/entrypoint.py` |
+| Why does a CPU command need a GPU host? | The dispatcher calls `nvidia-smi` unconditionally |
 | Why does my new subtask ignore `num_gpus`? | Multi-GPU is keyed on the literal subtask name `generate` |
 | Why is there no `status.json` for a subtask? | The script lacks `@monitor_status`; refer to the coverage list in the [Codebase tour](codebase_tour.md) |
 | Which model does auto-label use? | `auto_label/scripts/generate.py` dispatches on `cfg.autolabel_type` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,14 +1,66 @@
 # Architecture
 
-TAO Data Services is a source package plus a Dockerized runtime. Host users
-enter through `tao_ds`; in-container users enter through package console
-scripts. This guide explains the runtime dispatch, configuration flow, model
-usage, and service boundaries. For a directory-level orientation, read the
-[Codebase tour](codebase_tour.md) first.
+This guide explains what TAO Data Services is, how customers run it, and how a
+command flows through the source code. For a directory-level orientation, read
+the [Codebase tour](codebase_tour.md) first.
+
+## What TAO Data Services Is
+
+TAO Data Services is the dataset-preparation backend of the TAO ecosystem: a
+set of GPU-accelerated services for annotation conversion, data augmentation,
+auto-labeling, dataset analytics, data mining, and model-gap analysis. This
+repository is its source. It ships to users as one container,
+`nvcr.io/nvidia/tao/tao-toolkit:<version>-dataservices`, alongside the sibling
+backends built from tao-pytorch (training) and tao-deploy (TensorRT inference).
+
+The product surface is the set of console commands this package installs
+(`annotations`, `augmentation`, `auto_label`, `analytics`, `image`,
+`embedding`, `tmm`, `gap_analysis`) plus their subtasks. Everything else in
+this repository exists to build, validate, or develop that container.
+
+## How Users Run Data Services
+
+As of TAO 7.0 there is one supported user surface, with the container CLI
+underneath it:
+
+1. **Agent and TAO skills (current).** Users load the `tao-skills` plugin in a
+   coding agent and ask for the outcome ("convert these COCO annotations to
+   KITTI"). The skills and the TAO Execution SDK dispatch a job to the user's
+   compute backend (local Docker, DGX Cloud Lepton, Brev, SLURM, or
+   Kubernetes), which runs the data-services container and invokes the same
+   console commands documented here.
+2. **Container CLI (the layer underneath).** Inside the
+   `<version>-dataservices` container, users or automation run the commands
+   directly: `annotations convert -e spec.yaml`, `embedding image_embeddings
+   -e spec.yaml`, and so on. The public data-mining and auto-label
+   documentation shows this form.
+
+Two older surfaces were **removed in TAO 7.0** and should not appear in new
+code or documentation: the **TAO Launcher** (`tao dataset annotations convert
+...`, deprecated in 6.0) and **FTMS** (the Fine-Tuning MicroService REST API
+plus the `nvidia-tao-client` CLI/SDK). This repository still contains
+FTMS-era code paths (`nvidia_tao_ds/api/`, the microservice `CMD` in the
+release Dockerfile, `JOB_ID`-gated log teeing); treat them as legacy
+integration surfaces, not as the way users run the product.
+
+## Terminology
+
+| Term | Meaning here |
+| :--- | :--- |
+| Service | One dataset-preparation domain with its own console command and package, such as `annotations` or `augmentation`. Also called a command family. |
+| Subtask | One operation of a service, implemented as one module in the service's `scripts/` package and selected as the first CLI argument: `annotations convert`, `analytics analyze`. |
+| Specification (spec) | The YAML experiment file passed with `-e`, validated against the service's dataclass schema. |
+| Shared command dispatcher | `nvidia_tao_ds/core/entrypoint/entrypoint.py` — the in-repo code every console command delegates to. Not a product. |
+| `tao_ds` | The **development-only** container launcher defined by `scripts/envsetup.sh` (a shell function over `runner/tao_ds.py`). Users never see it; public docs reuse the name as a nickname for the data-services container itself. |
+| TAO Launcher | The removed `tao` CLI product (deprecated 6.0, removed 7.0). Not related to `tao_ds` or to the dispatcher above. |
+| FTMS | The removed Fine-Tuning MicroService REST API and `nvidia-tao-client`. Its in-repo remnants are noted above. |
+
+## Developer Runtime: From Console Command to Script
 
 ![Runtime dispatch flow](assets/runtime_flow.svg)
 
-## Runtime Dispatch
+For development, `tao_ds` (dev-only, see Terminology) stands in for whatever
+runs the container in production:
 
 1. `source scripts/envsetup.sh` exports `NV_TAO_DS_TOP` and defines `tao_ds`.
 2. `tao_ds` runs `runner/tao_ds.py`, resolves the base image from
@@ -16,11 +68,14 @@ usage, and service boundaries. For a directory-level orientation, read the
    Docker with the requested GPUs, mounts, environment variables, shared
    memory, ulimits, UID/GID, and optional service-mode ports.
 3. Commands after `tao_ds --` execute inside the container.
+
+From here on the flow is identical for users and developers:
+
 4. `setup.py` installs one console script per service (`annotations`,
    `augmentation`, `auto_label`, `analytics`, `image`, `embedding`, `tmm`,
    `gap_analysis`).
-5. Every console script is a thin argparse shell over the shared launcher in
-   `nvidia_tao_ds/core/entrypoint/entrypoint.py`, which:
+5. Every console script is a thin argparse shell over the shared command
+   dispatcher in `nvidia_tao_ds/core/entrypoint/entrypoint.py`, which:
    * Discovers subtask modules from the service's `scripts/` package and
      injects the synthetic `default_specs` subtask.
    * Validates `-e/--experiment_spec_file` and converts it into Hydra
@@ -44,14 +99,14 @@ usage, and service boundaries. For a directory-level orientation, read the
 
 | Command | Package | Dispatch pattern | Compute |
 | :--- | :--- | :--- | :--- |
-| `annotations` | `nvidia_tao_ds/annotations` | Shared launcher: `convert`, `merge`, `slice`, `qa_to_llava_annotation`. | CPU |
-| `augmentation` | `nvidia_tao_ds/augmentation` | Shared launcher; DALI pipelines; MPI path for multi-GPU `generate`. | GPU |
-| `auto_label` | `nvidia_tao_ds/auto_label` | Shared launcher; `torchrun` path for multi-GPU `generate`; fans out on `autolabel_type`. | GPU or remote LLM |
-| `analytics` | `nvidia_tao_ds/data_analytics` | Shared launcher: `analyze`, `validate`, `kpi_analyze`. Config package is named `analytics`. | CPU |
-| `image` | `nvidia_tao_ds/image` | Shared launcher: `validate` (corrupted-image removal). | CPU |
-| `embedding` | `nvidia_tao_ds/mining/embedding` | Shared launcher: `image_embeddings`, `text_embeddings` (CLIP and SigLIP to Parquet). | GPU |
-| `tmm` | `nvidia_tao_ds/mining/tmm` | Shared launcher: `nearest_neighbors`, `unique_neighbor_matching` (RAPIDS). | GPU |
-| `gap_analysis` | `nvidia_tao_ds/rcca/gap_analysis` | Shared launcher: `object_detection`, `vcn_aoi`, `vlm_bcq`. | CPU |
+| `annotations` | `nvidia_tao_ds/annotations` | Shared dispatcher: `convert`, `merge`, `slice`, `qa_to_llava_annotation`. | CPU |
+| `augmentation` | `nvidia_tao_ds/augmentation` | Shared dispatcher; DALI pipelines; MPI path for multi-GPU `generate`. | GPU |
+| `auto_label` | `nvidia_tao_ds/auto_label` | Shared dispatcher; `torchrun` path for multi-GPU `generate`; fans out on `autolabel_type`. | GPU or remote LLM |
+| `analytics` | `nvidia_tao_ds/data_analytics` | Shared dispatcher: `analyze`, `validate`, `kpi_analyze`. Config package is named `analytics`. | CPU |
+| `image` | `nvidia_tao_ds/image` | Shared dispatcher: `validate` (corrupted-image removal). | CPU |
+| `embedding` | `nvidia_tao_ds/mining/embedding` | Shared dispatcher: `image_embeddings`, `text_embeddings` (CLIP and SigLIP to Parquet). | GPU |
+| `tmm` | `nvidia_tao_ds/mining/tmm` | Shared dispatcher: `nearest_neighbors`, `unique_neighbor_matching` (RAPIDS). | GPU |
+| `gap_analysis` | `nvidia_tao_ds/rcca/gap_analysis` | Shared dispatcher: `object_detection`, `vcn_aoi`, `vlm_bcq`. | CPU |
 
 `get_subtasks()` wires a shared `default_specs` helper into every command, but
 it only works for the flat services (`annotations`, `augmentation`,
@@ -66,7 +121,7 @@ Most command scripts combine four pieces:
 
 | Layer | Example | Purpose |
 | :--- | :--- | :--- |
-| Entrypoint wrapper | `nvidia_tao_ds/annotations/entrypoint/annotations.py` | Parses the subtask and delegates to the shared launcher. |
+| Entrypoint wrapper | `nvidia_tao_ds/annotations/entrypoint/annotations.py` | Parses the subtask and delegates to the shared dispatcher. |
 | Script subtask | `nvidia_tao_ds/annotations/scripts/convert.py` | Owns task logic and the `@hydra_runner(...)` declaration. |
 | Experiment spec | `nvidia_tao_ds/annotations/experiment_specs/annotations.yaml` | Example YAML selected by `-e` or direct Hydra overrides. |
 | Dataclass schema | `nvidia_tao_ds/config/annotations/default_config.py` | Structured defaults and schema used by Hydra, the API, and default-spec generation. |
@@ -128,10 +183,11 @@ Grounding DINO and MAL configuration dataclasses imported from `nvidia_tao_core`
 | `nvidia_tao_ds/core/llm_clients/` | `LLMClient` ABC, Gemini and OpenAI-compatible clients, `create_client` factory used by auto-label workflows. |
 | `nvidia_tao_ds/core/utils/dataset_loading.py` | Shared COCO/KITTI loading used across services. |
 
-## API Service
+## API Service (Legacy FTMS Integration)
 
-There are two API stories, and confusing them is the most common orientation
-mistake in this repo:
+FTMS was removed as a product surface in TAO 7.0, but its integration code is
+still in this repository. There are two API stories, and confusing them is the
+most common orientation mistake in this repository:
 
 * **Dev-mode API:** `nvidia_tao_ds/api/app.py` is a self-contained Flask app
   exposing neural-network action discovery, schema lookup, action submission,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,10 @@
 # Architecture
 
 TAO Data Services is a source package plus a Dockerized runtime. Host users
-enter through `tao_ds`; in-container users enter through package console scripts.
+enter through `tao_ds`; in-container users enter through package console
+scripts. This guide explains the runtime dispatch, configuration flow, model
+usage, and service boundaries. For a directory-level orientation, read the
+[Codebase tour](codebase_tour.md) first.
 
 ![Runtime dispatch flow](assets/runtime_flow.svg)
 
@@ -9,87 +12,170 @@ enter through `tao_ds`; in-container users enter through package console scripts
 
 1. `source scripts/envsetup.sh` exports `NV_TAO_DS_TOP` and defines `tao_ds`.
 2. `tao_ds` runs `runner/tao_ds.py`, resolves the base image from
-   `docker/manifest.json`, mounts the repository as `/workspace`, sets
-   `PYTHONPATH=/workspace:$PYTHONPATH`, and starts Docker with the requested
-   GPUs, mounts, environment variables, shared memory, ulimits, UID/GID, and
-   optional service-mode ports.
+   `docker/manifest.json`, mounts the repository as `/workspace`, and starts
+   Docker with the requested GPUs, mounts, environment variables, shared
+   memory, ulimits, UID/GID, and optional service-mode ports.
 3. Commands after `tao_ds --` execute inside the container.
-4. `setup.py` installs package commands for data-service domains.
-5. Standard commands call `nvidia_tao_ds/core/entrypoint/entrypoint.py`, which
-   discovers subtask modules from each package's `scripts/` directory, validates
-   `-e/--experiment_spec_file`, injects `--config-path` and `--config-name`, and
-   launches the selected Python script.
-6. Script modules use `nvidia_tao_ds/core/hydra/hydra_runner.py` to run Hydra,
-   disable `.hydra` output directories, register optional dataclass schemas, and
-   preserve stdout-oriented logging.
+4. `setup.py` installs one console script per service (`annotations`,
+   `augmentation`, `auto_label`, `analytics`, `image`, `embedding`, `tmm`,
+   `gap_analysis`).
+5. Every console script is a thin argparse shell over the shared launcher in
+   `nvidia_tao_ds/core/entrypoint/entrypoint.py`, which:
+   * Discovers subtask modules from the service's `scripts/` package and
+     injects the synthetic `default_specs` subtask.
+   * Validates `-e/--experiment_spec_file` and converts it into Hydra
+     `--config-path`/`--config-name` flags, passing unknown CLI tokens through
+     as Hydra overrides.
+   * Applies multi-GPU settings only for subtasks in `multigpu_support`
+     (default: `['generate']`) and, when more than one GPU is requested,
+     selects the runner: `mpirun` for `augmentation`, `torchrun` for
+     `auto_label`, and plain `python` otherwise.
+   * Spawns the selected script as a **fresh Python subprocess**, streaming
+     stdout (and to `$TAO_MICROSERVICES_TTY_LOG/$JOB_ID/microservices_log.txt`
+     when `JOB_ID` is set).
+   * Reports telemetry and determines success from **both** the exit code and
+     the last record of `results_dir/status.json`.
+6. Script modules use `nvidia_tao_ds/core/hydra/hydra_runner.py` to register
+   the dataclass schema and run Hydra, and `@monitor_status` from
+   `core/decorators.py` to create the results directory, write `status.json`,
+   and map exceptions to user-facing status messages.
 
 ## Command Families
 
-| Command | Package | Dispatch Pattern |
-| :--- | :--- | :--- |
-| `augmentation` | `nvidia_tao_ds/augmentation` | Shared launcher with `-e`; MPI path for multi-GPU `generate`. |
-| `auto_label` | `nvidia_tao_ds/auto_label` | Shared launcher with `-e`; `torchrun` path for multi-GPU `generate`. |
-| `annotations` | `nvidia_tao_ds/annotations` | Shared launcher with `convert`, `merge`, `slice`, and QA conversion subtasks. |
-| `analytics` | `nvidia_tao_ds/data_analytics` | Shared launcher; config package is named `analytics`. |
-| `image` | `nvidia_tao_ds/image` | Shared launcher for image validation. |
-| `embedding` | `nvidia_tao_ds/mining/embedding` | Direct dispatcher that forwards Hydra args to `image_embeddings`. |
-| `tmm` | `nvidia_tao_ds/mining/tmm` | Direct dispatcher that forwards Hydra args to `nearest_neighbors`. |
-| `gap_analysis` | `nvidia_tao_ds/rcca/gap_analysis` | Direct dispatcher for `vcn_aoi` and `vlm_bcq`. |
+| Command | Package | Dispatch pattern | Compute |
+| :--- | :--- | :--- | :--- |
+| `annotations` | `nvidia_tao_ds/annotations` | Shared launcher: `convert`, `merge`, `slice`, `qa_to_llava_annotation`. | CPU |
+| `augmentation` | `nvidia_tao_ds/augmentation` | Shared launcher; DALI pipelines; MPI path for multi-GPU `generate`. | GPU |
+| `auto_label` | `nvidia_tao_ds/auto_label` | Shared launcher; `torchrun` path for multi-GPU `generate`; fans out on `autolabel_type`. | GPU or remote LLM |
+| `analytics` | `nvidia_tao_ds/data_analytics` | Shared launcher: `analyze`, `validate`, `kpi_analyze`. Config package is named `analytics`. | CPU |
+| `image` | `nvidia_tao_ds/image` | Shared launcher: `validate` (corrupted-image removal). | CPU |
+| `embedding` | `nvidia_tao_ds/mining/embedding` | Shared launcher: `image_embeddings`, `text_embeddings` (CLIP and SigLIP to Parquet). | GPU |
+| `tmm` | `nvidia_tao_ds/mining/tmm` | Shared launcher: `nearest_neighbors`, `unique_neighbor_matching` (RAPIDS). | GPU |
+| `gap_analysis` | `nvidia_tao_ds/rcca/gap_analysis` | Shared launcher: `object_detection`, `vcn_aoi`, `vlm_bcq`. | CPU |
 
-`get_subtasks()` also wires a shared `default_specs` helper. Before documenting
-or relying on that helper for a domain, check
-`nvidia_tao_ds/core/utils/default_specs.py` and the matching
-`nvidia_tao_ds/config/` layout; nested domains such as mining and RCCA do not
-follow the same flat module pattern as `annotations` or `augmentation`.
+`get_subtasks()` wires a shared `default_specs` helper into every command, but
+it only works for the flat services (`annotations`, `augmentation`,
+`auto_label`, `image`, `analytics`); `nvidia_tao_ds/core/utils/default_specs.py` does not support the nested
+mining and RCCA domains.
 
 ## Configuration Flow
 
-Most command scripts combine three files:
+![Configuration flow](assets/config_flow.svg)
+
+Most command scripts combine four pieces:
 
 | Layer | Example | Purpose |
 | :--- | :--- | :--- |
 | Entrypoint wrapper | `nvidia_tao_ds/annotations/entrypoint/annotations.py` | Parses the subtask and delegates to the shared launcher. |
 | Script subtask | `nvidia_tao_ds/annotations/scripts/convert.py` | Owns task logic and the `@hydra_runner(...)` declaration. |
 | Experiment spec | `nvidia_tao_ds/annotations/experiment_specs/annotations.yaml` | Example YAML selected by `-e` or direct Hydra overrides. |
-| Dataclass schema | `nvidia_tao_ds/config/annotations/default_config.py` | Structured defaults and schema used by Hydra/API/default-spec generation. |
+| Dataclass schema | `nvidia_tao_ds/config/annotations/default_config.py` | Structured defaults and schema used by Hydra, the API, and default-spec generation. |
 
-Do not infer spec names from subtask names. The source of truth is each
-script's `@hydra_runner(config_name=...)`. For example, the `annotations`
-`convert` subtask uses `config_name="annotations"`, while `qa_to_llava_annotation`
-uses `config_name="qa_to_llava"`.
+The configuration precedence at runtime is:
+
+```text
+dataclass defaults -> experiment YAML (-e) -> command-line Hydra overrides
+```
+
+Two schema conventions coexist:
+
+* **Flat services** keep their schemas in `config/<service>/`, anchored by a
+  `default_config.py::ExperimentConfig`. Subtasks may add sibling modules:
+  `annotations` pairs `ExperimentConfig` (convert) with `merge_config.py` and
+  `slice_config.py`, while `qa_to_llava_annotation` defines its configuration
+  inline in the script.
+* **Newer nested services** (mining, rcca) define one configuration module per
+  subtask, named after the subtask (for example,
+  `config/mining/tmm/nearest_neighbors.py::NearestNeighborsConfig`).
+
+Schemas declare their fields through typed factories from `config/utils/types.py`
+(`STR_FIELD`, `INT_FIELD`, `FLOAT_FIELD`, `BOOL_FIELD`, `LIST_FIELD`,
+`DICT_FIELD`, `DATACLASS_FIELD`, ...). Each factory attaches metadata —
+`description`, `display_name`, `valid_options`, `valid_min`/`valid_max`,
+`default_value`, and `automl_enabled`) consumed by the API schema layer and
+default-specification generation.
+
+Do not infer specification names from subtask names. The source of truth is each
+script's `@hydra_runner(config_name=...)`. For example, `annotations convert`
+uses `config_name="annotations"`, `qa_to_llava_annotation` uses
+`config_name="qa_to_llava"`, and `augmentation generate` uses
+`config_name="kitti"`.
+
+## Models and Weights
+
+Data services orchestrate models from other TAO repositories rather than
+defining their own:
+
+| Consumer | Model | Source |
+| :--- | :--- | :--- |
+| `auto_label generate` (`autolabel_type=grounding_dino`) | Grounding DINO (text-prompted boxes, iterative refinement) | `tao-pytorch` submodule (`nvidia_tao_pytorch.cv.grounding_dino`); user-supplied checkpoint |
+| `auto_label generate` (`autolabel_type=mal`) | MAL (box-to-segmentation pseudo-labels) | `tao-pytorch` submodule (`nvidia_tao_pytorch.cv.mal`); PL checkpoint |
+| `auto_label generate` (VLM workflows) | Remote VLM/LLM (Gemini or any OpenAI-compatible endpoint) | `core/llm_clients/` (`create_client`); needs `GOOGLE_API_KEY` or `OPENAI_API_KEY` |
+| `embedding image_embeddings` / `text_embeddings` | CLIP and SigLIP | Hugging Face `transformers` by model ID, or a TAO CLIP checkpoint via `nvidia_tao_pytorch.multimodal.clip` |
+
+The schema side mirrors this: `config/auto_label/default_config.py` composes
+Grounding DINO and MAL configuration dataclasses imported from `nvidia_tao_core`.
 
 ## Shared Services
 
 | Module | Responsibility |
 | :--- | :--- |
-| `nvidia_tao_ds/core/entrypoint/entrypoint.py` | Subtask discovery, spec path conversion, GPU override precedence, process launch, telemetry, and log teeing. |
-| `nvidia_tao_ds/core/hydra/hydra_runner.py` | Local wrapper around Hydra's internal runner with schema registration and TAO-friendly logging overrides. |
-| `nvidia_tao_ds/core/utils/default_specs.py` | Default experiment YAML generation from dataclass configs. |
-| `nvidia_tao_ds/core/logging/` | TAO Data Services logging helpers. |
-| `nvidia_tao_ds/core/llm_clients/` | OpenAI-compatible, Gemini, and base LLM client abstractions used by auto-label workflows. |
+| `nvidia_tao_ds/core/entrypoint/entrypoint.py` | Subtask discovery, spec path conversion, GPU override precedence, process launch, telemetry, log teeing, status-based failure detection. |
+| `nvidia_tao_ds/core/hydra/hydra_runner.py` | Local wrapper around Hydra's runner with schema registration and TAO-friendly logging overrides. |
+| `nvidia_tao_ds/core/decorators.py` | `@monitor_status` (results dir, `status.json`, error classification) and `@experimental`. |
+| `nvidia_tao_ds/core/utils/default_specs.py` | Default experiment YAML generation from dataclass configs (flat services only). |
+| `nvidia_tao_ds/core/logging/` | `StatusLogger` and dual logging into `status.json`. |
+| `nvidia_tao_ds/core/llm_clients/` | `LLMClient` ABC, Gemini and OpenAI-compatible clients, `create_client` factory used by auto-label workflows. |
+| `nvidia_tao_ds/core/utils/dataset_loading.py` | Shared COCO/KITTI loading used across services. |
 
 ## API Service
 
-`nvidia_tao_ds/api/app.py` is a Flask application with OpenAPI endpoints under
-`/api/v1`. It exposes neural-network action discovery, schema lookup, action
-submission, job status, health, OpenAPI JSON/YAML, Swagger, and Redoc routes.
+There are two API stories, and confusing them is the most common orientation
+mistake in this repo:
 
-The API uses `nvidia_tao_core.api_utils.module_utils` to map installed console
-scripts to actions, `dataclass2json_converter` for schema materialization, and
-`json_schema_validation` before queueing jobs. A background thread processes the
-shared `process_queue`. Service-mode container launch is handled by
-`runner/tao_ds.py --run_as_service`.
+* **Dev-mode API:** `nvidia_tao_ds/api/app.py` is a self-contained Flask app
+  exposing neural-network action discovery, schema lookup, action submission,
+  job status, and health routes under `/api/v1`, plus OpenAPI, Swagger, and
+  Redoc routes at the root. It maps
+  installed console scripts to actions via
+  `nvidia_tao_core.api_utils.module_utils`, validates specifications with
+  `json_schema_validation`, and processes jobs on a background queue thread. It
+  is reachable only through the dev launcher: `tao_ds --run_as_service`. The
+  contract snapshot is `nvidia_tao_ds/api/openapi.json`.
+* **Production microservice:** the release container
+  (`release/docker/Dockerfile.release`) does **not** run `app.py`. It sets
+  `FLASK_APP=nvidia_tao_core.microservices.app` and runs tao-core's
+  microservice; the broader control plane (datasets, experiments, job
+  orchestration) lives in TAO API, not this repository.
+
+## TAO Core and TAO PyTorch Boundaries
+
+Both are git submodules; initialize them before running anything:
+
+```sh
+git submodule update --init
+```
+
+* **`tao-core/`** provides telemetry (soft-imported), status callbacks
+  (imported by `core/logging/logging.py`), API utilities used by `api/app.py`,
+  and the Grounding DINO and MAL configuration dataclasses composed into
+  `config/auto_label/`. The release image builds and installs its wheel and
+  uses its microservice app as the container entrypoint. For local
+  development, `scripts/envsetup.sh` puts `/workspace/tao-core` on
+  `PYTHONPATH`.
+* **`tao-pytorch/`** supplies the actual model code for Grounding DINO, MAL,
+  and TAO CLIP checkpoints consumed by `auto_label` and `embedding`.
 
 ## Extension Points
 
 Add a new workflow by choosing the smallest surface:
 
-| Change | Typical Files |
+| Change | Typical files |
 | :--- | :--- |
-| New subtask in an existing command | `nvidia_tao_ds/$DOMAIN/scripts/$SUBTASK.py`, `experiment_specs/`, `config/`, tests. |
-| New top-level command | New package with `entrypoint/`, `scripts/`, `experiment_specs/`, config package, `setup.py` entry, tests, README generator update. |
-| New API-visible action | Command/config support plus `api/app.py` and any `tao-core` module utility mapping changes. |
-| New container dependency | `docker/requirements-pip.txt`, `docker/Dockerfile`, `docker/build.sh`, `docker/manifest.json` after push. |
+| New subtask in an existing command | `nvidia_tao_ds/<service>/scripts/<subtask>.py`, `experiment_specs/`, `config/`, tests. Remember: multi-GPU only applies if the subtask is named `generate`, and `status.json` requires `@monitor_status`. |
+| New top-level command | New package with `entrypoint/`, `scripts/`, `experiment_specs/`, a config package, a `setup.py` entry, tests, and a README-generator run. |
+| New API-visible action | Command/config support plus `api/app.py` and any tao-core module-utility mapping changes. |
+| New container dependency | `docker/requirements-pip.txt`, `docker/Dockerfile`, then `docker/build.sh` and a `docker/manifest.json` digest update after push. Video/codec dependencies must respect the FFmpeg codec allow-list baked into the Dockerfile. |
 
-Use [new_data_service_command.md](new_data_service_command.md) before adding a
-new command or promoting a pattern as canonical.
+Refer to [New data-service command](new_data_service_command.md) before adding
+a new command or promoting a pattern as canonical.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ the [Codebase tour](codebase_tour.md) first.
 ## What TAO Data Services Is
 
 TAO Data Services is the dataset-preparation backend of the TAO ecosystem: a
-set of GPU-accelerated services for annotation conversion, data augmentation,
+collection of dataset-preparation functions covering annotation conversion, data augmentation,
 auto-labeling, dataset analytics, data mining, and model-gap analysis. This
 repository is its source. It ships to users as one container,
 `nvcr.io/nvidia/tao/tao-toolkit:<version>-dataservices`, alongside the sibling
@@ -47,9 +47,9 @@ integration surfaces, not as the way users run the product.
 
 | Term | Meaning here |
 | :--- | :--- |
-| Service | One dataset-preparation domain with its own console command and package, such as `annotations` or `augmentation`. Also called a command family. |
-| Subtask | One operation of a service, implemented as one module in the service's `scripts/` package and selected as the first CLI argument: `annotations convert`, `analytics analyze`. |
-| Specification (spec) | The YAML experiment file passed with `-e`, validated against the service's dataclass schema. |
+| Function | One dataset-preparation capability with its own console command and package, such as `annotations` or `augmentation`. Functions are classified by compute: **GPU functions** (`augmentation`, `auto_label`, `embedding`, `tmm`) and **CPU functions** (`annotations`, `analytics`, `image`, `gap_analysis`). Despite the product name "Data Services," these are batch CLI functions, not long-running services. |
+| Subtask | One operation of a function, implemented as one module in the function's `scripts/` package and selected as the first CLI argument: `annotations convert`, `analytics analyze`. |
+| Specification (spec) | The YAML experiment file passed with `-e`, validated against the function's dataclass schema. |
 | Shared command dispatcher | `nvidia_tao_ds/core/entrypoint/entrypoint.py` — the in-repo code every console command delegates to. Not a product. |
 | `tao_ds` | The **development-only** container launcher defined by `scripts/envsetup.sh` (a shell function over `runner/tao_ds.py`). Users never see it; public docs reuse the name as a nickname for the data-services container itself. |
 | TAO Launcher | The removed `tao` CLI product (deprecated 6.0, removed 7.0). Not related to `tao_ds` or to the dispatcher above. |
@@ -71,12 +71,12 @@ runs the container in production:
 
 From here on the flow is identical for users and developers:
 
-4. `setup.py` installs one console script per service (`annotations`,
+4. `setup.py` installs one console script per function (`annotations`,
    `augmentation`, `auto_label`, `analytics`, `image`, `embedding`, `tmm`,
    `gap_analysis`).
 5. Every console script is a thin argparse shell over the shared command
    dispatcher in `nvidia_tao_ds/core/entrypoint/entrypoint.py`, which:
-   * Discovers subtask modules from the service's `scripts/` package and
+   * Discovers subtask modules from the function's `scripts/` package and
      injects the synthetic `default_specs` subtask.
    * Validates `-e/--experiment_spec_file` and converts it into Hydra
      `--config-path`/`--config-name` flags, passing unknown CLI tokens through
@@ -95,9 +95,9 @@ From here on the flow is identical for users and developers:
    `core/decorators.py` to create the results directory, write `status.json`,
    and map exceptions to user-facing status messages.
 
-## Command Families
+## Function Inventory
 
-| Command | Package | Dispatch pattern | Compute |
+| Function | Package | Dispatch pattern | Compute |
 | :--- | :--- | :--- | :--- |
 | `annotations` | `nvidia_tao_ds/annotations` | Shared dispatcher: `convert`, `merge`, `slice`, `qa_to_llava_annotation`. | CPU |
 | `augmentation` | `nvidia_tao_ds/augmentation` | Shared dispatcher; DALI pipelines; MPI path for multi-GPU `generate`. | GPU |
@@ -109,7 +109,7 @@ From here on the flow is identical for users and developers:
 | `gap_analysis` | `nvidia_tao_ds/rcca/gap_analysis` | Shared dispatcher: `object_detection`, `vcn_aoi`, `vlm_bcq`. | CPU |
 
 `get_subtasks()` wires a shared `default_specs` helper into every command, but
-it only works for the flat services (`annotations`, `augmentation`,
+it only works for the flat functions (`annotations`, `augmentation`,
 `auto_label`, `image`, `analytics`); `nvidia_tao_ds/core/utils/default_specs.py` does not support the nested
 mining and RCCA domains.
 
@@ -134,12 +134,12 @@ dataclass defaults -> experiment YAML (-e) -> command-line Hydra overrides
 
 Two schema conventions coexist:
 
-* **Flat services** keep their schemas in `config/<service>/`, anchored by a
+* **Flat functions** keep their schemas in `config/<function>/`, anchored by a
   `default_config.py::ExperimentConfig`. Subtasks may add sibling modules:
   `annotations` pairs `ExperimentConfig` (convert) with `merge_config.py` and
   `slice_config.py`, while `qa_to_llava_annotation` defines its configuration
   inline in the script.
-* **Newer nested services** (mining, rcca) define one configuration module per
+* **Newer nested functions** (mining, rcca) define one configuration module per
   subtask, named after the subtask (for example,
   `config/mining/tmm/nearest_neighbors.py::NearestNeighborsConfig`).
 
@@ -158,7 +158,7 @@ uses `config_name="annotations"`, `qa_to_llava_annotation` uses
 
 ## Models and Weights
 
-Data services orchestrate models from other TAO repositories rather than
+The functions orchestrate models from other TAO repositories rather than
 defining their own:
 
 | Consumer | Model | Source |
@@ -178,10 +178,10 @@ Grounding DINO and MAL configuration dataclasses imported from `nvidia_tao_core`
 | `nvidia_tao_ds/core/entrypoint/entrypoint.py` | Subtask discovery, spec path conversion, GPU override precedence, process launch, telemetry, log teeing, status-based failure detection. |
 | `nvidia_tao_ds/core/hydra/hydra_runner.py` | Local wrapper around Hydra's runner with schema registration and TAO-friendly logging overrides. |
 | `nvidia_tao_ds/core/decorators.py` | `@monitor_status` (results dir, `status.json`, error classification) and `@experimental`. |
-| `nvidia_tao_ds/core/utils/default_specs.py` | Default experiment YAML generation from dataclass configs (flat services only). |
+| `nvidia_tao_ds/core/utils/default_specs.py` | Default experiment YAML generation from dataclass configs (flat functions only). |
 | `nvidia_tao_ds/core/logging/` | `StatusLogger` and dual logging into `status.json`. |
 | `nvidia_tao_ds/core/llm_clients/` | `LLMClient` ABC, Gemini and OpenAI-compatible clients, `create_client` factory used by auto-label workflows. |
-| `nvidia_tao_ds/core/utils/dataset_loading.py` | Shared COCO/KITTI loading used across services. |
+| `nvidia_tao_ds/core/utils/dataset_loading.py` | Shared COCO/KITTI loading used across functions. |
 
 ## API Service (Legacy FTMS Integration)
 
@@ -228,7 +228,7 @@ Add a new workflow by choosing the smallest surface:
 
 | Change | Typical files |
 | :--- | :--- |
-| New subtask in an existing command | `nvidia_tao_ds/<service>/scripts/<subtask>.py`, `experiment_specs/`, `config/`, tests. Remember: multi-GPU only applies if the subtask is named `generate`, and `status.json` requires `@monitor_status`. |
+| New subtask in an existing command | `nvidia_tao_ds/<function>/scripts/<subtask>.py`, `experiment_specs/`, `config/`, tests. Remember: multi-GPU only applies if the subtask is named `generate`, and `status.json` requires `@monitor_status`. |
 | New top-level command | New package with `entrypoint/`, `scripts/`, `experiment_specs/`, a config package, a `setup.py` entry, tests, and a README-generator run. |
 | New API-visible action | Command/config support plus `api/app.py` and any tao-core module-utility mapping changes. |
 | New container dependency | `docker/requirements-pip.txt`, `docker/Dockerfile`, then `docker/build.sh` and a `docker/manifest.json` digest update after push. Video/codec dependencies must respect the FFmpeg codec allow-list baked into the Dockerfile. |

--- a/docs/assets/config_flow.svg
+++ b/docs/assets/config_flow.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="940" height="330" viewBox="0 0 940 330" role="img" aria-labelledby="title desc">
+  <title id="title">TAO Data Services configuration flow</title>
+  <desc id="desc">Configuration flows from dataclass defaults to experiment YAML to Hydra overrides and into service scripts.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#475569"/>
+    </marker>
+    <style>
+      .box { fill: #f8fafc; stroke: #334155; stroke-width: 1.5; rx: 10; }
+      .schema { fill: #eef2ff; stroke: #4f46e5; stroke-width: 1.7; rx: 10; }
+      .runtime { fill: #ecfdf5; stroke: #047857; stroke-width: 1.7; rx: 10; }
+      .label { font: 600 15px Arial, sans-serif; fill: #111827; }
+      .small { font: 12px Arial, sans-serif; fill: #374151; }
+      .path { stroke: #475569; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+      .merge { stroke: #94a3b8; stroke-width: 1.5; stroke-dasharray: 5 4; fill: none; }
+    </style>
+  </defs>
+
+  <text x="470" y="30" text-anchor="middle" class="label">Configuration Flow</text>
+
+  <rect x="45" y="82" width="170" height="78" class="schema"/>
+  <text x="130" y="108" text-anchor="middle" class="label">Dataclass schema</text>
+  <text x="130" y="130" text-anchor="middle" class="small">config/&lt;service&gt;</text>
+  <text x="130" y="147" text-anchor="middle" class="small">defaults + metadata</text>
+
+  <rect x="275" y="82" width="170" height="78" class="box"/>
+  <text x="360" y="108" text-anchor="middle" class="label">Experiment YAML (-e)</text>
+  <text x="360" y="130" text-anchor="middle" class="small">experiment_specs/</text>
+  <text x="360" y="147" text-anchor="middle" class="small">named by config_name</text>
+
+  <rect x="505" y="82" width="170" height="78" class="box"/>
+  <text x="590" y="108" text-anchor="middle" class="label">Hydra overrides</text>
+  <text x="590" y="130" text-anchor="middle" class="small">results_dir=/results</text>
+  <text x="590" y="147" text-anchor="middle" class="small">CLI dotlist</text>
+
+  <rect x="735" y="82" width="160" height="78" class="runtime"/>
+  <text x="815" y="108" text-anchor="middle" class="label">Structured cfg</text>
+  <text x="815" y="130" text-anchor="middle" class="small">cfg passed to</text>
+  <text x="815" y="147" text-anchor="middle" class="small">script main(cfg)</text>
+
+  <rect x="275" y="230" width="170" height="58" class="runtime"/>
+  <text x="360" y="255" text-anchor="middle" class="label">default_specs</text>
+  <text x="360" y="275" text-anchor="middle" class="small">flat services only</text>
+
+  <rect x="735" y="230" width="160" height="58" class="runtime"/>
+  <text x="815" y="255" text-anchor="middle" class="label">Service code</text>
+  <text x="815" y="275" text-anchor="middle" class="small">convert/augment/label</text>
+
+  <path d="M215 121 H275" class="path"/>
+  <path d="M445 121 H505" class="path"/>
+  <path d="M675 121 H735" class="path"/>
+  <path d="M130 160 V259 H275" class="path"/>
+  <path d="M815 160 V230" class="path"/>
+  <path d="M215 121 C240 55 480 55 505 121" class="merge"/>
+  <path d="M445 121 C470 188 710 188 735 121" class="merge"/>
+</svg>

--- a/docs/assets/module_map.svg
+++ b/docs/assets/module_map.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="540" viewBox="0 0 980 540" role="img" aria-labelledby="title desc">
+  <title id="title">TAO Data Services package module map</title>
+  <desc id="desc">The nvidia_tao_ds package groups service families over shared launcher, config, logging, and LLM-client modules, with models supplied by submodules.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#475569"/>
+    </marker>
+    <style>
+      .zone { fill: #f8fafc; stroke: #94a3b8; stroke-width: 1.2; stroke-dasharray: 6 4; rx: 12; }
+      .family { fill: #eef2ff; stroke: #4f46e5; stroke-width: 1.7; rx: 10; }
+      .shared { fill: #ecfdf5; stroke: #047857; stroke-width: 1.7; rx: 10; }
+      .config { fill: #fef3c7; stroke: #b45309; stroke-width: 1.7; rx: 10; }
+      .ext { fill: #fee2e2; stroke: #b91c1c; stroke-width: 1.7; rx: 10; }
+      .label { font: 600 15px Arial, sans-serif; fill: #111827; }
+      .small { font: 12px Arial, sans-serif; fill: #374151; }
+      .zonelabel { font: 700 13px Arial, sans-serif; fill: #64748b; letter-spacing: 1px; }
+      .path { stroke: #475569; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+    </style>
+  </defs>
+
+  <text x="490" y="28" text-anchor="middle" class="label">nvidia_tao_ds Module Map</text>
+
+  <rect x="30" y="50" width="920" height="160" class="zone"/>
+  <text x="50" y="72" class="zonelabel">SERVICE FAMILIES (one console script each)</text>
+
+  <rect x="55" y="90" width="200" height="100" class="family"/>
+  <text x="155" y="114" text-anchor="middle" class="label">CPU services</text>
+  <text x="155" y="134" text-anchor="middle" class="small">annotations (convert/merge/slice)</text>
+  <text x="155" y="151" text-anchor="middle" class="small">data_analytics ("analytics")</text>
+  <text x="155" y="168" text-anchor="middle" class="small">image, rcca/gap_analysis</text>
+
+  <rect x="285" y="90" width="200" height="100" class="family"/>
+  <text x="385" y="114" text-anchor="middle" class="label">GPU services</text>
+  <text x="385" y="134" text-anchor="middle" class="small">augmentation (DALI/mpirun)</text>
+  <text x="385" y="151" text-anchor="middle" class="small">auto_label (torchrun)</text>
+  <text x="385" y="168" text-anchor="middle" class="small">mining/embedding, mining/tmm</text>
+
+  <rect x="515" y="90" width="200" height="100" class="config"/>
+  <text x="615" y="114" text-anchor="middle" class="label">config/</text>
+  <text x="615" y="134" text-anchor="middle" class="small">flat: default_config.py</text>
+  <text x="615" y="151" text-anchor="middle" class="small">nested: per-subtask modules</text>
+  <text x="615" y="168" text-anchor="middle" class="small">utils/types.py: *_FIELD factories</text>
+
+  <rect x="745" y="90" width="180" height="100" class="family"/>
+  <text x="835" y="114" text-anchor="middle" class="label">api/</text>
+  <text x="835" y="134" text-anchor="middle" class="small">dev-mode Flask app</text>
+  <text x="835" y="151" text-anchor="middle" class="small">(tao_ds --run_as_service)</text>
+  <text x="835" y="168" text-anchor="middle" class="small">openapi.json contract</text>
+
+  <rect x="30" y="230" width="920" height="140" class="zone"/>
+  <text x="50" y="252" class="zonelabel">SHARED CORE</text>
+
+  <rect x="55" y="268" width="300" height="84" class="shared"/>
+  <text x="205" y="292" text-anchor="middle" class="label">core/entrypoint/entrypoint.py</text>
+  <text x="205" y="312" text-anchor="middle" class="small">subtask discovery, spec-to-Hydra, GPU</text>
+  <text x="205" y="329" text-anchor="middle" class="small">handling, subprocess launch, telemetry</text>
+
+  <rect x="385" y="268" width="270" height="84" class="shared"/>
+  <text x="520" y="292" text-anchor="middle" class="label">core/</text>
+  <text x="520" y="312" text-anchor="middle" class="small">hydra_runner, monitor_status,</text>
+  <text x="520" y="329" text-anchor="middle" class="small">StatusLogger, default_specs</text>
+
+  <rect x="685" y="268" width="240" height="84" class="shared"/>
+  <text x="805" y="292" text-anchor="middle" class="label">core/llm_clients/</text>
+  <text x="805" y="312" text-anchor="middle" class="small">Gemini + OpenAI-compatible</text>
+  <text x="805" y="329" text-anchor="middle" class="small">clients for VLM auto-labeling</text>
+
+  <rect x="30" y="390" width="920" height="130" class="zone"/>
+  <text x="50" y="412" class="zonelabel">EXTERNAL MODEL AND INFRA SOURCES (git submodules)</text>
+
+  <rect x="55" y="428" width="400" height="72" class="ext"/>
+  <text x="255" y="452" text-anchor="middle" class="label">tao-pytorch/</text>
+  <text x="255" y="472" text-anchor="middle" class="small">Grounding DINO, MAL, TAO CLIP model code</text>
+  <text x="255" y="489" text-anchor="middle" class="small">used by auto_label and embedding</text>
+
+  <rect x="495" y="428" width="430" height="72" class="ext"/>
+  <text x="710" y="452" text-anchor="middle" class="label">tao-core/</text>
+  <text x="710" y="472" text-anchor="middle" class="small">telemetry, status callbacks, api_utils, GDINO/MAL config</text>
+  <text x="710" y="489" text-anchor="middle" class="small">dataclasses; release-container microservice app</text>
+
+  <path d="M155 190 L205 268" class="path"/>
+  <path d="M385 190 L385 230 L355 268" class="path"/>
+  <path d="M615 190 L615 230 L560 268" class="path"/>
+  <path d="M835 190 L835 230 L805 268" class="path"/>
+  <path d="M255 352 L255 428" class="path"/>
+  <path d="M710 352 L710 428" class="path"/>
+</svg>

--- a/docs/codebase_tour.md
+++ b/docs/codebase_tour.md
@@ -6,7 +6,7 @@ each directory is for, how the Python package is organized into modules, and
 where the sharp edges are.
 
 For what the product is, how customers run it, and definitions of the terms
-used below (service, subtask, dispatcher, `tao_ds`), read the opening sections
+used below (function, subtask, dispatcher, `tao_ds`), read the opening sections
 of [Architecture](architecture.md) first; this repository builds the
 `nvcr.io/nvidia/tao/tao-toolkit:<version>-dataservices` container, and the
 console commands below are its user-facing surface.
@@ -26,7 +26,7 @@ tao-dataservices/
 │   ├── mining/               # embedding (CLIP/SigLIP -> parquet) and tmm (RAPIDS nearest-neighbor mining)
 │   ├── rcca/                 # gap_analysis: model-failure / coverage analysis
 │   ├── core/                 # Shared command dispatcher, Hydra runner, decorators, logging, LLM clients
-│   ├── config/               # Hydra dataclass schemas, one package per service
+│   ├── config/               # Hydra dataclass schemas, one package per function
 │   ├── api/                  # Dev-mode Flask API (refer to the API section in Architecture)
 │   ├── backbone/             # Vendored FAN/ConvNeXt/Swin/ViT code (legacy, unused elsewhere)
 │   └── dataclass_to_rst/     # Doc tooling: config dataclasses -> RST tables for public docs
@@ -41,7 +41,7 @@ tao-dataservices/
 ├── .github/                  # GitHub Actions workflows and shared hook scripts
 ├── tao-core/                 # Git submodule: shared TAO config/microservice/telemetry code
 ├── tao-pytorch/              # Git submodule: model code consumed by auto_label and embedding
-├── setup.py                  # Package definition and console_scripts (one per service)
+├── setup.py                  # Package definition and console_scripts (one per function)
 └── Makefile                  # Wheel build targets (build, install, develop, clean)
 ```
 
@@ -57,22 +57,25 @@ The rules of thumb are:
 
 | Module | Role | Key files |
 | :--- | :--- | :--- |
-| `<service>/entrypoint/` | An approximately 35-line argparse shell delegating to the shared dispatcher. | For example, `annotations/entrypoint/annotations.py` |
-| `<service>/scripts/` | One module per subtask; each owns its `@hydra_runner(...)` declaration. | For example, `annotations/scripts/convert.py` |
-| `<service>/experiment_specs/` | Example YAML specifications selected by `-e`. | For example, `annotations/experiment_specs/annotations.yaml` |
+| `<function>/entrypoint/` | An approximately 35-line argparse shell delegating to the shared dispatcher. | For example, `annotations/entrypoint/annotations.py` |
+| `<function>/scripts/` | One module per subtask; each owns its `@hydra_runner(...)` declaration. | For example, `annotations/scripts/convert.py` |
+| `<function>/experiment_specs/` | Example YAML specifications selected by `-e`. | For example, `annotations/experiment_specs/annotations.yaml` |
 | `core/entrypoint/entrypoint.py` | The shared command dispatcher: subtask discovery, spec-to-Hydra translation, GPU handling, subprocess launch, telemetry, and status-based failure detection. | `get_subtasks`, `launch` |
 | `core/hydra/hydra_runner.py` | Schema registration and Hydra invocation. | `hydra_runner` decorator |
 | `core/decorators.py` | `@monitor_status` (results dir, `status.json`, error classification) and `@experimental`. | |
 | `core/logging/` | `StatusLogger`, dual logging into `status.json`. | `logging.py` |
 | `core/llm_clients/` | LLM/VLM client abstraction used by auto-label workflows. | `LLMClient` ABC, `GeminiClient`, `OpenAICompatibleClient`, and the `create_client` factory |
 | `core/utils/` | `default_specs` pseudo-subtask, shared COCO/KITTI loading, video helpers. | `default_specs.py`, `dataset_loading.py`, `video_utils.py` |
-| `config/<service>/` | Dataclass schemas (refer to [Two Configuration Conventions](#two-configuration-conventions)). | `default_config.py` and per-subtask modules |
+| `config/<function>/` | Dataclass schemas (refer to [Two Configuration Conventions](#two-configuration-conventions)). | `default_config.py` and per-subtask modules |
 | `config/utils/types.py` | Typed field factories (`STR_FIELD`, `INT_FIELD`, `DATACLASS_FIELD`, ...) that attach UI/validation metadata. | |
-| `api/` | Dev-mode Flask app exposing services as API actions. | `app.py`, `openapi.json` |
+| `api/` | Dev-mode Flask app exposing the functions as API actions. | `app.py`, `openapi.json` |
 
-## Service Inventory
+## Function Inventory
 
-Each console script (registered in `setup.py`) maps to one service package:
+Despite the product name "Data Services," the units of this repository are
+batch CLI **functions**, not long-running services; they are classified by
+compute as GPU functions or CPU functions. Each console script (registered in
+`setup.py`) maps to one function package:
 
 | Command | Package | Subtasks | Runs on |
 | :--- | :--- | :--- | :--- |
@@ -95,7 +98,7 @@ The `auto_label generate` subtask fans out on `cfg.autolabel_type`:
 | `image_referring_expression` | VLM four-step referring-expression workflow | Remote VLM |
 | `video_reasoning_annotation` | Multi-step video captioning/QA workflow | Remote VLM + LLM |
 
-## Anatomy of One Service: `annotations`
+## Anatomy of One Function: `annotations`
 
 ```text
 nvidia_tao_ds/annotations/
@@ -141,12 +144,12 @@ directly with `--config-path`/`--config-name` to debug it in-process.
 
 The configuration tree has two generations of layout:
 
-* **Flat (older services):** Schemas live in `config/<service>/`, anchored by
+* **Flat (older functions):** Schemas live in `config/<function>/`, anchored by
   `default_config.py::ExperimentConfig`: `annotations`, `augmentation`,
   `auto_label`, `image`, and `analytics` (the schema package for
   `data_analytics/`). Subtasks may add sibling modules; `annotations` pairs
   `ExperimentConfig` (convert) with `merge_config.py` and `slice_config.py`.
-* **Per-subtask (newer services):** One configuration module per subtask:
+* **Per-subtask (newer functions):** One configuration module per subtask:
   `config/mining/embedding/image_embeddings.py` (`ImageEmbeddingsConfig`),
   `config/mining/tmm/nearest_neighbors.py` (`NearestNeighborsConfig`),
   `config/rcca/gap_analysis/*.py`, and so on.
@@ -164,8 +167,8 @@ The following behaviors surprise every new developer; they are collected in one 
   is `config/analytics/`. `core/utils/default_specs.py` carries an explicit
   alias map to reconcile them.
 * **`default_specs` does not support mining or rcca.** It only recognizes
-  services with a flat `nvidia_tao_ds/<dir>/entrypoint/` layout and a
-  `config/<dir>/default_config.py`. The nested `mining/*` and `rcca/*` services
+  functions with a flat `nvidia_tao_ds/<dir>/entrypoint/` layout and a
+  `config/<dir>/default_config.py`. The nested `mining/*` and `rcca/*` functions
   fail with "Module ... is not supported" even though `default_specs` appears
   in their subtask lists.
 * **Every command requires `nvidia-smi`**, including pure-CPU ones; the shared

--- a/docs/codebase_tour.md
+++ b/docs/codebase_tour.md
@@ -3,8 +3,13 @@
 This is a guided walk through the TAO Data Services repository for developers
 picking up the codebase for the first time. It answers three questions: what
 each directory is for, how the Python package is organized into modules, and
-where the sharp edges are. For the runtime and data-flow view, read
-[Architecture](architecture.md) next.
+where the sharp edges are.
+
+For what the product is, how customers run it, and definitions of the terms
+used below (service, subtask, dispatcher, `tao_ds`), read the opening sections
+of [Architecture](architecture.md) first; this repository builds the
+`nvcr.io/nvidia/tao/tao-toolkit:<version>-dataservices` container, and the
+console commands below are its user-facing surface.
 
 ![TAO Data Services module map](assets/module_map.svg)
 
@@ -20,7 +25,7 @@ tao-dataservices/
 │   ├── image/                # Corrupted-image validation (CPU)
 │   ├── mining/               # embedding (CLIP/SigLIP -> parquet) and tmm (RAPIDS nearest-neighbor mining)
 │   ├── rcca/                 # gap_analysis: model-failure / coverage analysis
-│   ├── core/                 # Shared launcher, Hydra runner, decorators, logging, LLM clients
+│   ├── core/                 # Shared command dispatcher, Hydra runner, decorators, logging, LLM clients
 │   ├── config/               # Hydra dataclass schemas, one package per service
 │   ├── api/                  # Dev-mode Flask API (refer to the API section in Architecture)
 │   ├── backbone/             # Vendored FAN/ConvNeXt/Swin/ViT code (legacy, unused elsewhere)
@@ -52,10 +57,10 @@ The rules of thumb are:
 
 | Module | Role | Key files |
 | :--- | :--- | :--- |
-| `<service>/entrypoint/` | An approximately 35-line argparse shell delegating to the shared launcher. | For example, `annotations/entrypoint/annotations.py` |
+| `<service>/entrypoint/` | An approximately 35-line argparse shell delegating to the shared dispatcher. | For example, `annotations/entrypoint/annotations.py` |
 | `<service>/scripts/` | One module per subtask; each owns its `@hydra_runner(...)` declaration. | For example, `annotations/scripts/convert.py` |
 | `<service>/experiment_specs/` | Example YAML specifications selected by `-e`. | For example, `annotations/experiment_specs/annotations.yaml` |
-| `core/entrypoint/entrypoint.py` | The shared launcher: subtask discovery, spec-to-Hydra translation, GPU handling, subprocess launch, telemetry, and status-based failure detection. | `get_subtasks`, `launch` |
+| `core/entrypoint/entrypoint.py` | The shared command dispatcher: subtask discovery, spec-to-Hydra translation, GPU handling, subprocess launch, telemetry, and status-based failure detection. | `get_subtasks`, `launch` |
 | `core/hydra/hydra_runner.py` | Schema registration and Hydra invocation. | `hydra_runner` decorator |
 | `core/decorators.py` | `@monitor_status` (results dir, `status.json`, error classification) and `@experimental`. | |
 | `core/logging/` | `StatusLogger`, dual logging into `status.json`. | `logging.py` |
@@ -94,7 +99,7 @@ The `auto_label generate` subtask fans out on `cfg.autolabel_type`:
 
 ```text
 nvidia_tao_ds/annotations/
-├── entrypoint/annotations.py     # argparse shell -> core launcher
+├── entrypoint/annotations.py     # argparse shell -> shared dispatcher
 ├── scripts/convert.py            # @hydra_runner(config_name="annotations", schema=ExperimentConfig)
 ├── scripts/{merge,slice,qa_to_llava_annotation}.py
 ├── conversion/                   # The format-conversion engine
@@ -163,8 +168,8 @@ The following behaviors surprise every new developer; they are collected in one 
   `config/<dir>/default_config.py`. The nested `mining/*` and `rcca/*` services
   fail with "Module ... is not supported" even though `default_specs` appears
   in their subtask lists.
-* **Every command requires `nvidia-smi`**, including pure-CPU ones — the shared
-  launcher unconditionally counts GPUs. The CLI cannot run on a GPU-less host.
+* **Every command requires `nvidia-smi`**, including pure-CPU ones; the shared
+  dispatcher unconditionally counts GPUs. The CLI cannot run on a GPU-less host.
 * **Multi-GPU parsing is keyed on the literal subtask name `generate`.**
   `launch(multigpu_support=['generate'], ...)` — a new GPU subtask with any
   other name silently runs single-GPU and ignores spec-level
@@ -174,7 +179,7 @@ The following behaviors surprise every new developer; they are collected in one 
   annotations `convert`/`merge`/`slice`, `augmentation generate`,
   `auto_label generate`, analytics `analyze`/`validate`, and `image validate`
   — and absent on `qa_to_llava_annotation`, `kpi_analyze`, all of `mining/*`,
-  and all of `rcca/*`. For the latter group the launcher's status-based
+  and all of `rcca/*`. For the latter group the dispatcher's status-based
   failure check is a no-op.
 * **`augmentation`'s default `config_name` is `"kitti"`**, not `generate`; its
   `experiment_specs/` holds `kitti.yaml` and `coco.yaml`. Always read the

--- a/docs/codebase_tour.md
+++ b/docs/codebase_tour.md
@@ -1,0 +1,201 @@
+# Codebase Tour
+
+This is a guided walk through the TAO Data Services repository for developers
+picking up the codebase for the first time. It answers three questions: what
+each directory is for, how the Python package is organized into modules, and
+where the sharp edges are. For the runtime and data-flow view, read
+[Architecture](architecture.md) next.
+
+![TAO Data Services module map](assets/module_map.svg)
+
+## Repository Layout
+
+```text
+tao-dataservices/
+├── nvidia_tao_ds/            # The installable Python package (everything shipped in the wheel)
+│   ├── annotations/          # Format conversion, merge, slice (CPU)
+│   ├── augmentation/         # DALI-based data augmentation (GPU, MPI multi-GPU)
+│   ├── auto_label/           # Pseudo-label generation: Grounding DINO, MAL, VLM workflows (GPU / remote LLM)
+│   ├── data_analytics/       # Dataset analytics, validation, KPI analysis (command name: analytics)
+│   ├── image/                # Corrupted-image validation (CPU)
+│   ├── mining/               # embedding (CLIP/SigLIP -> parquet) and tmm (RAPIDS nearest-neighbor mining)
+│   ├── rcca/                 # gap_analysis: model-failure / coverage analysis
+│   ├── core/                 # Shared launcher, Hydra runner, decorators, logging, LLM clients
+│   ├── config/               # Hydra dataclass schemas, one package per service
+│   ├── api/                  # Dev-mode Flask API (refer to the API section in Architecture)
+│   ├── backbone/             # Vendored FAN/ConvNeXt/Swin/ViT code (legacy, unused elsewhere)
+│   └── dataclass_to_rst/     # Doc tooling: config dataclasses -> RST tables for public docs
+├── runner/tao_ds.py          # Host-side Docker launcher (not shipped in the wheel)
+├── scripts/envsetup.sh       # Defines the tao_ds shell function; installs git hooks
+├── docker/                   # Base development image: Dockerfile, manifest.json, requirements
+├── release/                  # Release image, version metadata (release/python/version.py)
+├── internal/                 # Unpackaged dev scripts (dataset split, KITTI visualization)
+├── tools/                    # update_readme_supported_commands.py (generates the README command table)
+├── tests/                    # pytest suites (flat files + tests/autolabel + tests/mining)
+├── docs/                     # This documentation
+├── .github/                  # GitHub Actions workflows and shared hook scripts
+├── tao-core/                 # Git submodule: shared TAO config/microservice/telemetry code
+├── tao-pytorch/              # Git submodule: model code consumed by auto_label and embedding
+├── setup.py                  # Package definition and console_scripts (one per service)
+└── Makefile                  # Wheel build targets (build, install, develop, clean)
+```
+
+The rules of thumb are:
+
+* If it ships to users, it lives under `nvidia_tao_ds/`.
+* If it launches or builds containers, it lives in `runner/`, `docker/`, or
+  `release/`.
+* If it validates the repository, it lives in `tests/`, `.pre-commit-config.yaml`, or
+  `.github/workflows/`.
+
+## The Package in One Table
+
+| Module | Role | Key files |
+| :--- | :--- | :--- |
+| `<service>/entrypoint/` | An approximately 35-line argparse shell delegating to the shared launcher. | For example, `annotations/entrypoint/annotations.py` |
+| `<service>/scripts/` | One module per subtask; each owns its `@hydra_runner(...)` declaration. | For example, `annotations/scripts/convert.py` |
+| `<service>/experiment_specs/` | Example YAML specifications selected by `-e`. | For example, `annotations/experiment_specs/annotations.yaml` |
+| `core/entrypoint/entrypoint.py` | The shared launcher: subtask discovery, spec-to-Hydra translation, GPU handling, subprocess launch, telemetry, and status-based failure detection. | `get_subtasks`, `launch` |
+| `core/hydra/hydra_runner.py` | Schema registration and Hydra invocation. | `hydra_runner` decorator |
+| `core/decorators.py` | `@monitor_status` (results dir, `status.json`, error classification) and `@experimental`. | |
+| `core/logging/` | `StatusLogger`, dual logging into `status.json`. | `logging.py` |
+| `core/llm_clients/` | LLM/VLM client abstraction used by auto-label workflows. | `LLMClient` ABC, `GeminiClient`, `OpenAICompatibleClient`, and the `create_client` factory |
+| `core/utils/` | `default_specs` pseudo-subtask, shared COCO/KITTI loading, video helpers. | `default_specs.py`, `dataset_loading.py`, `video_utils.py` |
+| `config/<service>/` | Dataclass schemas (refer to [Two Configuration Conventions](#two-configuration-conventions)). | `default_config.py` and per-subtask modules |
+| `config/utils/types.py` | Typed field factories (`STR_FIELD`, `INT_FIELD`, `DATACLASS_FIELD`, ...) that attach UI/validation metadata. | |
+| `api/` | Dev-mode Flask app exposing services as API actions. | `app.py`, `openapi.json` |
+
+## Service Inventory
+
+Each console script (registered in `setup.py`) maps to one service package:
+
+| Command | Package | Subtasks | Runs on |
+| :--- | :--- | :--- | :--- |
+| `annotations` | `annotations/` | `convert`, `merge`, `slice`, `qa_to_llava_annotation` | CPU |
+| `augmentation` | `augmentation/` | `generate` | GPU (DALI; multi-GPU via `mpirun`) |
+| `auto_label` | `auto_label/` | `generate` (dispatches on `autolabel_type`) | GPU (`torchrun`) or remote LLM APIs |
+| `analytics` | `data_analytics/` | `analyze`, `validate`, `kpi_analyze` | CPU |
+| `image` | `image/` | `validate` | CPU |
+| `embedding` | `mining/embedding/` | `image_embeddings`, `text_embeddings` | GPU |
+| `tmm` | `mining/tmm/` | `nearest_neighbors`, `unique_neighbor_matching` | GPU (RAPIDS `cudf`/`cuml`) |
+| `gap_analysis` | `rcca/gap_analysis/` | `object_detection`, `vcn_aoi`, `vlm_bcq` | CPU |
+
+The `auto_label generate` subtask fans out on `cfg.autolabel_type`:
+
+| `autolabel_type` | What it does | Model source |
+| :--- | :--- | :--- |
+| `grounding_dino` | Text-prompted box pseudo-labels with iterative refinement | Grounding DINO built from the `tao-pytorch` submodule; user-supplied checkpoint |
+| `mal` | Box-to-segmentation pseudo-labels | MAL from `tao-pytorch`; PL checkpoint |
+| `image_grounding` | VLM two-step expression extraction + grounding | Remote VLM via `core/llm_clients` |
+| `image_referring_expression` | VLM four-step referring-expression workflow | Remote VLM |
+| `video_reasoning_annotation` | Multi-step video captioning/QA workflow | Remote VLM + LLM |
+
+## Anatomy of One Service: `annotations`
+
+```text
+nvidia_tao_ds/annotations/
+├── entrypoint/annotations.py     # argparse shell -> core launcher
+├── scripts/convert.py            # @hydra_runner(config_name="annotations", schema=ExperimentConfig)
+├── scripts/{merge,slice,qa_to_llava_annotation}.py
+├── conversion/                   # The format-conversion engine
+│   └── mapping.py                # CONVERSION_MAPPING: {input_format: {output_format: converter_fn}}
+├── merger.py                     # Merger ABC -> COCOMerger, LLaVAMerger, ODVGMerger
+├── slicer.py                     # Slicer ABC -> COCO{Random,Number,Category,Filename}Slicer
+└── experiment_specs/*.yaml       # 11 example specs
+nvidia_tao_ds/config/annotations/
+├── default_config.py             # ExperimentConfig (convert)
+├── merge_config.py               # MergeConfig
+└── slice_config.py               # SliceConfig
+```
+
+Command flow for `annotations convert -e spec.yaml results_dir=/results`:
+
+1. The `annotations` console script calls
+   `annotations/entrypoint/annotations.py:main`.
+2. `core/entrypoint/entrypoint.py::get_subtasks()` discovers `scripts/*.py` as
+   subtasks and injects the synthetic `default_specs` subtask.
+3. `launch()` converts `-e` into Hydra `--config-path`/`--config-name` flags,
+   passes unknown CLI tokens through as Hydra overrides, and **spawns a fresh
+   `python .../scripts/convert.py` subprocess**, teeing stdout (and to
+   `$TAO_MICROSERVICES_TTY_LOG/$JOB_ID/microservices_log.txt` when `JOB_ID` is
+   set).
+4. Inside the child, `@hydra_runner(..., schema=ExperimentConfig)` validates the
+   YAML, and `@monitor_status(...)` creates the results directory and writes
+   `status.json`.
+5. `run_conversion(cfg)` dispatches through
+   `CONVERSION_MAPPING[input_format][output_format]`.
+6. Back in the parent, failure is detected two ways: the subprocess exit code
+   **and** the last record of `results_dir/status.json` — a subtask that exits
+   0 but logged `FAILURE` is still reported as failed.
+
+The subprocess step matters for debugging: breakpoints set in a `scripts/*.py`
+are never hit when you launch via the console command. Run the script module
+directly with `--config-path`/`--config-name` to debug it in-process.
+
+## Two Configuration Conventions
+
+The configuration tree has two generations of layout:
+
+* **Flat (older services):** Schemas live in `config/<service>/`, anchored by
+  `default_config.py::ExperimentConfig`: `annotations`, `augmentation`,
+  `auto_label`, `image`, and `analytics` (the schema package for
+  `data_analytics/`). Subtasks may add sibling modules; `annotations` pairs
+  `ExperimentConfig` (convert) with `merge_config.py` and `slice_config.py`.
+* **Per-subtask (newer services):** One configuration module per subtask:
+  `config/mining/embedding/image_embeddings.py` (`ImageEmbeddingsConfig`),
+  `config/mining/tmm/nearest_neighbors.py` (`NearestNeighborsConfig`),
+  `config/rcca/gap_analysis/*.py`, and so on.
+
+Fields in both use the factories from `config/utils/types.py`, which attach
+`description`, `valid_options`, `valid_min`/`valid_max`, and related metadata
+consumed by specification generation and the FTMS/API layer.
+
+## Sharp Edges
+
+The following behaviors surprise every new developer; they are collected in one place:
+
+* **`data_analytics` versus `analytics`.** The package directory is
+  `data_analytics/`, the console script is `analytics`, and the configuration package
+  is `config/analytics/`. `core/utils/default_specs.py` carries an explicit
+  alias map to reconcile them.
+* **`default_specs` does not support mining or rcca.** It only recognizes
+  services with a flat `nvidia_tao_ds/<dir>/entrypoint/` layout and a
+  `config/<dir>/default_config.py`. The nested `mining/*` and `rcca/*` services
+  fail with "Module ... is not supported" even though `default_specs` appears
+  in their subtask lists.
+* **Every command requires `nvidia-smi`**, including pure-CPU ones — the shared
+  launcher unconditionally counts GPUs. The CLI cannot run on a GPU-less host.
+* **Multi-GPU parsing is keyed on the literal subtask name `generate`.**
+  `launch(multigpu_support=['generate'], ...)` — a new GPU subtask with any
+  other name silently runs single-GPU and ignores spec-level
+  `num_gpus`/`gpu_ids`. `augmentation` uses `mpirun`, `auto_label` uses
+  `torchrun`; the choice is keyed on the `network=` string.
+* **Not every subtask writes `status.json`.** `@monitor_status` is present on
+  annotations `convert`/`merge`/`slice`, `augmentation generate`,
+  `auto_label generate`, analytics `analyze`/`validate`, and `image validate`
+  — and absent on `qa_to_llava_annotation`, `kpi_analyze`, all of `mining/*`,
+  and all of `rcca/*`. For the latter group the launcher's status-based
+  failure check is a no-op.
+* **`augmentation`'s default `config_name` is `"kitti"`**, not `generate`; its
+  `experiment_specs/` holds `kitti.yaml` and `coco.yaml`. Always read the
+  `@hydra_runner(config_name=...)` line rather than inferring from the subtask
+  name.
+* **`vllm_captioning` is a dangling auto-label option.** It appears in the
+  configuration's `valid_options`, but `ExperimentConfig` has no such field and
+  the script raises `NotImplementedError`; selecting it fails with an
+  `AttributeError` from configuration validation.
+* **`nvidia_tao_ds/backbone/` is vendored legacy code** (FAN/ConvNeXt/Swin/ViT;
+  the FAN-derived files carry an additional NVlabs Source Code License-NC
+  notice) imported by nothing else in the package. Do not extend it.
+* **The Docker image enforces a codec policy.** The base image builds an
+  LGPL-only FFmpeg (VP9/mjpeg encode only; H.264 decode is hardware-only) and
+  OpenCV without FFmpeg, with build-time assertions that fail the image if
+  restricted codecs reappear. Any video-handling change must stay inside that
+  allow-list (`core/utils/video_utils.py` uses `libvpx-vp9`).
+* **Two API stories exist.** `nvidia_tao_ds/api/app.py` is a dev-mode Flask app
+  reachable only via `tao_ds --run_as_service`; the release container instead
+  runs the tao-core microservice app. Refer to [Architecture](architecture.md).
+* **No pytest configuration file exists.** There is no `conftest.py` or
+  `pytest.ini`; several GPU/data-heavy tests skip themselves when
+  `CI_PROJECT_DIR` is set (a GitLab-era guard) and need private scratch
+  datasets mounted. Prefer path-based test selection.

--- a/docs/development_workflows.md
+++ b/docs/development_workflows.md
@@ -61,9 +61,9 @@ find tests -name '*annotation*' -o -name '*merger*' | sort
 7. Run `python tools/update_readme_supported_commands.py` if command metadata,
    subtask files, launcher options, or image digests changed.
 
-When adding a subtask, remember two launcher behaviors keyed on names: only
+When adding a subtask, remember two dispatcher behaviors keyed on names: only
 subtasks named `generate` get multi-GPU handling, and only scripts decorated
-with `@monitor_status` write `status.json` (which the launcher reads to detect
+with `@monitor_status` write `status.json` (which the dispatcher reads to detect
 failures).
 
 ## Update Configuration Defaults

--- a/docs/development_workflows.md
+++ b/docs/development_workflows.md
@@ -1,12 +1,18 @@
 # Development Workflows
 
+This guide gives concrete recipes for common source-code changes.
+
 These recipes assume you have already run:
 
 ```sh
+git submodule update --init
 source scripts/envsetup.sh
 ```
 
-## Build Or Install The Package
+`envsetup.sh` sets `NV_TAO_DS_TOP`, defines the `tao_ds` shell function, and
+installs the repository's pre-commit hooks.
+
+## Build or Install the Package
 
 Inside the development container:
 
@@ -24,54 +30,81 @@ python3 setup.py develop
 `release/python/version.py` owns the package name, package description, version
 components, and package metadata used by `setup.py`.
 
-## Change A Command Or Subtask
+## Trace a Command to Code
+
+Use this when a task mentions a command such as `annotations convert`.
+
+```sh
+rg -n "annotations" setup.py
+sed -n '1,80p' nvidia_tao_ds/annotations/entrypoint/annotations.py
+sed -n '1,120p' nvidia_tao_ds/annotations/scripts/convert.py
+rg -n "config_name=" nvidia_tao_ds/annotations/scripts/
+```
+
+Then inspect the specifications, schema, and tests:
+
+```sh
+find nvidia_tao_ds/annotations/experiment_specs -maxdepth 1 -type f | sort
+find nvidia_tao_ds/config/annotations -maxdepth 1 -type f | sort
+find tests -name '*annotation*' -o -name '*merger*' | sort
+```
+
+## Change a Command or Subtask
 
 1. Find the command in `setup.py`.
 2. Open its package under `nvidia_tao_ds/`.
 3. Read the package `entrypoint/` wrapper and the target file in `scripts/`.
-4. Check the matching example YAML under `experiment_specs/`.
+4. Check the matching example YAML under `experiment_specs/` and the
+   `@hydra_runner(config_name=...)` declaration.
 5. Check the matching dataclass schema under `nvidia_tao_ds/config/`.
 6. Update focused tests under `tests/`.
 7. Run `python tools/update_readme_supported_commands.py` if command metadata,
    subtask files, launcher options, or image digests changed.
 
-Standard command wrappers require `-e/--experiment_spec_file` for normal
-subtasks. Mining and RCCA direct dispatchers forward Hydra arguments directly,
-so mirror their existing tests before changing their CLI behavior.
+When adding a subtask, remember two launcher behaviors keyed on names: only
+subtasks named `generate` get multi-GPU handling, and only scripts decorated
+with `@monitor_status` write `status.json` (which the launcher reads to detect
+failures).
 
-## Update Config Defaults
+## Update Configuration Defaults
 
-Flat command configs live under `nvidia_tao_ds/config/<module>/`. The analytics
-command is implemented in `nvidia_tao_ds/data_analytics/` but its config package
-is `nvidia_tao_ds/config/analytics/`.
+Flat command configurations live under `nvidia_tao_ds/config/<module>/`. The analytics
+command is implemented in `nvidia_tao_ds/data_analytics/` but its configuration
+package is `nvidia_tao_ds/config/analytics/`.
 
-Nested domains use nested config packages:
+Nested domains use nested, per-subtask configuration packages:
 
-| Domain | Config Path |
+| Domain | Config path |
 | :--- | :--- |
 | TMM mining | `nvidia_tao_ds/config/mining/tmm/` |
 | Embedding mining | `nvidia_tao_ds/config/mining/embedding/` |
 | RCCA gap analysis | `nvidia_tao_ds/config/rcca/gap_analysis/` |
 
-After config changes, run focused config and command tests:
+Declare new fields with the factories from
+`nvidia_tao_ds/config/utils/types.py` (`STR_FIELD`, `INT_FIELD`, ...), including
+a `description`; the metadata feeds the API schema layer and default-specification
+generation.
+
+After configuration changes, run focused configuration tests:
 
 ```sh
 pytest tests/test_config_modules.py -q
-pytest tests/mining/test_mining_entrypoints.py -q
 ```
 
-## Update The API Service
+## Update the API Service
 
-API routes live in `nvidia_tao_ds/api/app.py`. The service relies on installed
-console scripts and `nvidia_tao_core.api_utils.module_utils` for action
-discovery, so API-visible command changes may require coordinated changes in
-`tao-core/`.
+Dev-mode API routes live in `nvidia_tao_ds/api/app.py`. The service relies on
+installed console scripts and `nvidia_tao_core.api_utils.module_utils` for
+action discovery, so API-visible command changes may require coordinated
+changes in `tao-core/`.
 
-For schema behavior, check the relevant dataclass config and any tests that
+For schema behavior, check the relevant dataclass configuration and any tests that
 exercise API or default-spec imports. For endpoint inventory, compare
-`nvidia_tao_ds/api/app.py` and `nvidia_tao_ds/api/openapi.json`.
+`nvidia_tao_ds/api/app.py` and `nvidia_tao_ds/api/openapi.json`. The release
+container runs the tao-core microservice app, not this Flask app; refer to
+[Architecture](architecture.md).
 
-## Update The Base Development Image
+## Update the Base Development Image
 
 Use `docker/build.sh` for the base image:
 
@@ -84,30 +117,25 @@ cd "$NV_TAO_DS_TOP/docker"
 
 Single-platform builds can load locally. Multi-platform builds require `--push`
 because Docker buildx cannot load multiple architectures into the local Docker
-daemon at once. After pushing, update `docker/manifest.json` with the digest
-printed by the build script.
+daemon at once.
 
-**Update every digest reference, not just `docker/manifest.json`.** The base-image
-digest is hardcoded in several files. A base-image rebuild must update all of them for
-the target architecture (`x86` and/or `arm`), or CI, Jenkins, and the release build will
-keep pulling the stale image:
+**Update every digest reference, not just `docker/manifest.json`.** After
+pushing, update the new digest in both places that pin it:
 
 | Location | What it drives |
 | :--- | :--- |
-| `docker/manifest.json` | `tao_ds` launcher + `ci/utils.py` (static/functional tests); per-arch `x86`/`arm` digests — the source of truth |
-| `.gitlab-ci.yml` | the `image:` the GitLab static-test jobs run in |
-| `Jenkinsfile.dev`, `Jenkinsfile.develop`, `Jenkinsfile.nightly` | the `base-image` container the Jenkins jobs run in |
-| `Jenkinsfile.release` | `BUILD_X86` / `BUILD_ARM` release base images |
-| `release/docker/Dockerfile.release` | `FROM` base digests for the release image |
+| `docker/manifest.json` | The `tao_ds` launcher; this is the source of truth for the per-architecture `x86` and `arm` digests |
+| `release/docker/Dockerfile.release` | Default `X86_DIGEST`/`ARM64_DIGEST` build args for the release image `FROM` lines |
 
-Find them all with `grep -rl <old-digest> .` and replace per architecture (the `x86`
-and `arm` digests are distinct strings, so a per-digest `sed` is safe). The
-`check_base_image_digests_consistent` static test (`ci/run_static_tests.py`) fails the build
-if any of these files references a digest not in `docker/manifest.json`, so a partial bump
-is caught in CI. The README intentionally does **not** carry the digests (they are internal
-`nvstaging` references, not useful in a public repo) — do not re-add them.
+Find any stragglers with `grep -rl <old-digest> .` and replace per architecture
+(the `x86` and `arm` digests are distinct strings, so a per-digest `sed` is
+safe). The README intentionally does **not** carry the digests, because they
+are internal `nvstaging` references that are not useful in a public
+repository; do not re-add them. Dependency changes to requirements or Docker
+files also trip the `dependency-guard` pre-commit hook, which requires
+explicit acknowledgment.
 
-## Update The Release Image
+## Update the Release Image
 
 Use `release/docker/deploy.sh` for the release image:
 
@@ -120,14 +148,19 @@ The script can build the source wheel through `tao_ds -- make build`, build
 `release/docker/Dockerfile.release`, push the release image, and clean wheels
 when `--wheel` is used.
 
+Any change touching video or codecs must respect the FFmpeg codec allow-list
+baked into `docker/Dockerfile` (an LGPL-only build with VP9 and mjpeg encode and no libx264, hevc, or aac). The image build asserts this and fails if restricted codecs
+reappear.
+
 ## Keep README Generated Content Fresh
 
 `README.md` contains a generated section for launcher options, console scripts,
-subtasks, and base-image digests. Update or check it with:
+subtasks, and the base-image manifest pointer. Update or check it with:
 
 ```sh
 python tools/update_readme_supported_commands.py
 python tools/update_readme_supported_commands.py --check
 ```
 
-The local pre-commit hook and GitLab `static_tests` job run the `--check` mode.
+The local pre-commit hook and the GitHub Actions `static-tests` workflow run
+the `--check` mode.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,11 @@ container power users working from the TAO Data Services source tree.
 The root `README.md` is intentionally concise. Start here when you need the
 repository mental model, command flow, configuration flow, or validation map.
 
+This repository is the source of the TAO data-services container
+(`nvcr.io/nvidia/tao/tao-toolkit:<version>-dataservices`). For what the product
+is, how customers run it, and the terminology the rest of these documents use,
+read the opening sections of [Architecture](architecture.md).
+
 ## Start Paths
 
 | Role | Start with | Then read |

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ read the opening sections of [Architecture](architecture.md).
 
 | Document | Purpose |
 | :--- | :--- |
-| [Codebase tour](codebase_tour.md) | Annotated repository tree, module map, service inventory, and the sharp edges new developers hit. |
+| [Codebase tour](codebase_tour.md) | Annotated repository tree, module map, function inventory, and the sharp edges new developers hit. |
 | [Agent onboarding](agent_onboarding.md) | First-pass audit commands, worktree safety, and source-of-truth files. |
 | [Architecture](architecture.md) | Runtime dispatch, Hydra config, models and weights, API service, and extension points. |
 | [Development workflows](development_workflows.md) | Recipes for common source, configuration, Docker, release, and README changes. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,9 @@ repository mental model, command flow, configuration flow, or validation map.
 
 ## Start Paths
 
-| Role | Start With | Then Read |
+| Role | Start with | Then read |
 | :--- | :--- | :--- |
+| New developer picking up the repository | [Codebase tour](codebase_tour.md) | [Architecture](architecture.md) |
 | Coding agent or new maintainer | [Agent onboarding](agent_onboarding.md) | [Architecture](architecture.md), [Testing and debugging](testing_and_debugging.md) |
 | Feature developer | [Development workflows](development_workflows.md) | [New data-service command](new_data_service_command.md) |
 | Container power user | [Container power users](container_power_users.md) | [Architecture](architecture.md) |
@@ -19,27 +20,28 @@ repository mental model, command flow, configuration flow, or validation map.
 
 | Document | Purpose |
 | :--- | :--- |
-| [agent_onboarding.md](agent_onboarding.md) | First-pass audit commands, worktree safety, and source-of-truth files. |
-| [architecture.md](architecture.md) | Runtime dispatch, Hydra config, API service, package layout, and extension points. |
-| [development_workflows.md](development_workflows.md) | Recipes for common source, config, Docker, release, and README changes. |
-| [testing_and_debugging.md](testing_and_debugging.md) | CI static checks, targeted pytest commands, GPU-sensitive paths, and failure triage. |
-| [container_power_users.md](container_power_users.md) | `tao_ds`, mounts, GPUs, base-image digests, service mode, and direct Docker equivalents. |
-| [new_data_service_command.md](new_data_service_command.md) | Source-backed guide for adding or extending commands and subtasks. |
+| [Codebase tour](codebase_tour.md) | Annotated repository tree, module map, service inventory, and the sharp edges new developers hit. |
+| [Agent onboarding](agent_onboarding.md) | First-pass audit commands, worktree safety, and source-of-truth files. |
+| [Architecture](architecture.md) | Runtime dispatch, Hydra config, models and weights, API service, and extension points. |
+| [Development workflows](development_workflows.md) | Recipes for common source, configuration, Docker, release, and README changes. |
+| [Testing and debugging](testing_and_debugging.md) | CI static checks, targeted pytest commands, GPU-sensitive paths, and failure triage. |
+| [Container power users](container_power_users.md) | `tao_ds`, mounts, GPUs, base-image digests, service mode, and direct Docker equivalents. |
+| [New data-service command](new_data_service_command.md) | Source-backed guide for adding or extending commands and subtasks. |
 
 ## Repository Anchors
 
-| Path | What To Look For |
+| Path | What to look for |
 | :--- | :--- |
-| `setup.py` | Package metadata and in-container console script entrypoints. |
-| `scripts/envsetup.sh` | `NV_TAO_DS_TOP` setup and the host-side `tao_ds` shell function. |
+| `setup.py` | Package metadata and in-container console script entry points. |
+| `scripts/envsetup.sh` | `NV_TAO_DS_TOP` setup, the host-side `tao_ds` shell function, and git-hook installation. |
 | `runner/tao_ds.py` | Docker launcher, GPU selection, mount handling, service mode, and manifest lookup. |
 | `nvidia_tao_ds/core/entrypoint/entrypoint.py` | Shared subtask discovery, experiment spec handling, GPU override handling, and subprocess launch. |
 | `nvidia_tao_ds/core/hydra/hydra_runner.py` | Local Hydra wrapper used by script modules. |
 | `nvidia_tao_ds/config/` | Dataclass-backed schemas and default-spec sources. |
 | `nvidia_tao_ds/*/experiment_specs/` | Example YAML specs used by script subtasks. |
-| `nvidia_tao_ds/api/app.py` | Flask API routes, job queue handoff, schema validation, and OpenAPI endpoints. |
+| `nvidia_tao_ds/api/app.py` | Dev-mode Flask API routes, job queue handoff, schema validation, and OpenAPI endpoints. |
 | `docker/manifest.json` | Immutable base-image registry, repository, and architecture-specific digests. |
-| `.gitlab-ci.yml` and `ci/` | Merge-request checks and static-test helpers. |
+| `.pre-commit-config.yaml` and `.github/workflows/` | Pull-request checks: lint, license headers, DCO, README drift, and secret scan. |
 
 ## Command Layers
 
@@ -59,7 +61,13 @@ launcher, or image-manifest metadata changes.
 
 ## Diagrams
 
+Architecture and workflow diagrams are checked in as SVG files under
+`docs/assets/` and embedded with normal Markdown image links. The SVG files are
+the canonical editable sources.
+
 | Diagram | Source |
 | :--- | :--- |
 | Runtime dispatch flow | [assets/runtime_flow.svg](assets/runtime_flow.svg) |
+| Configuration flow | [assets/config_flow.svg](assets/config_flow.svg) |
+| Package module map | [assets/module_map.svg](assets/module_map.svg) |
 | Container launch and build flow | [assets/container_flow.svg](assets/container_flow.svg) |

--- a/docs/testing_and_debugging.md
+++ b/docs/testing_and_debugging.md
@@ -1,32 +1,47 @@
-# Testing And Debugging
+# Testing and Debugging
 
 This repository mixes static checks, unit tests, command dispatch tests,
-container checks, and GPU/data-sensitive workflows. Pick the smallest test that
+container checks, and GPU- and data-sensitive workflows. Pick the smallest test that
 covers your change.
 
-## GitLab Static Tests
+## Static Checks
 
-`.gitlab-ci.yml` runs the `static_tests` job in the TAO Data Services base
-image. The job now checks generated README drift before running
-`ci/run_static_tests.py`.
+CI runs static checks on pull requests through GitHub Actions
+(`.github/workflows/static-tests.yml`), which executes the repository's pre-commit
+hooks against the changed files:
 
-`ci/run_static_tests.py` runs:
+* SPDX license headers (`.github/hooks/check_license_header.py`)
+* `pylint` (`.pylintrc`), `pydocstyle`, and `flake8`, scoped to
+  `nvidia_tao_ds/`
+* The generated README drift check
+  (`tools/update_readme_supported_commands.py --check`)
 
-| Tool | Scope |
-| :--- | :--- |
-| `pylint --rcfile .pylintrc` | Modules listed in `ci/utils.py` `TEST_MODULES`. |
-| `pydocstyle --ignore=D4,D200,D203,D205,D210,D212,D213,D301,D400,D401` | Same module list. |
-| `flake8 --ignore=E24,W504,E501` | Same module list. |
+CI skips the `trufflehog` and `dependency-guard` hooks (secret scanning runs
+in the separate `secret-scan.yml` workflow); both still run in the local
+pre-commit hook, and `dependency-guard` requires explicit acknowledgment for
+requirements and Docker file changes.
 
-`ci/utils.py` resolves the Docker image from `docker/manifest.json` for local
-static runs. In CI it runs directly in the job image.
+Reproduce locally:
 
-## Docs-Only Validation
+```sh
+pip install pre-commit
+pre-commit install
+pre-commit run --from-ref origin/main --to-ref HEAD
+```
+
+Separate workflows enforce DCO sign-off on every commit (`dco.yml`), secret
+scanning (`secret-scan.yml`), and PR title format (`pr-title.yml`).
+Functional (GPU) tests run through the externally triggered `blossom-ci.yml`
+workflow, not on every push.
+
+## Documentation-Only Validation
+
+For documentation-only changes, run these checks:
 
 ```sh
 python tools/update_readme_supported_commands.py --check
 python -m py_compile tools/update_readme_supported_commands.py
-git diff --check -- README.md docs/*.md docs/assets/*.svg tools/*.py .pre-commit-config.yaml .gitlab-ci.yml
+git diff --check -- README.md docs/*.md docs/assets/*.svg tools/*.py .pre-commit-config.yaml
 rg -n "TBD|PLACEHOLDER|example\\.com" README.md docs
 ```
 
@@ -35,43 +50,66 @@ the normal blast radius for documentation-only changes.
 
 ## Targeted Pytest Map
 
-| Change Area | Suggested Tests |
+| Change area | Suggested tests |
 | :--- | :--- |
 | Config package moves or default spec support | `pytest tests/test_config_modules.py -q` |
-| Mining dispatchers | `pytest tests/mining/test_mining_entrypoints.py -q` |
-| Embedding logic | `pytest tests/mining/test_image_embeddings.py -q` |
-| Nearest-neighbor mining | `pytest tests/mining/test_nearest_neighbors.py -q` |
+| Shared launcher / exit-code behavior | `pytest tests/test_entrypoint_exit_code.py -q` |
+| Embedding logic | `pytest tests/mining/test_image_embeddings.py tests/mining/test_text_embeddings.py -q` |
+| Nearest-neighbor mining | `pytest tests/mining/test_nearest_neighbors.py tests/mining/test_unique_neighbor_matching.py -q` |
 | Annotation merge/slice | `pytest tests/test_merger_slicer.py -q` |
-| COCO/KITTI conversion | `pytest tests/test_coco_kitti_conversion.py tests/test_coco_odvg_conversion.py -q` |
-| AICity conversion | `pytest tests/test_aicity_ovpkl_conversion.py -q` |
+| COCO, KITTI, and ODVG conversion | `pytest tests/test_coco_kitti_conversion.py tests/test_coco_odvg_conversion.py -q` |
+| AICity / PAS conversions | `pytest tests/test_aicity_ovpkl_conversion.py tests/test_nvidia_paidf_pas_to_tao_clip_conversion.py -q` |
 | QA to LLaVA conversion | `pytest tests/test_qa_to_llava_annotation.py tests/test_llava_merger.py -q` |
 | Analytics | `pytest tests/test_data_analytics.py -q` |
-| Auto-label prompt and parsing logic | `pytest tests/autolabel -q` |
-| Logging changes | `pytest tests/test_dual_logging.py tests/test_baselogger_recursion.py -q` |
+| Auto-label VLM workflows | `pytest tests/autolabel -q` |
+| Auto-label Grounding DINO | `pytest tests/test_text2box.py -q` |
+| Gap analysis | `pytest tests/test_od_gap_analysis.py tests/test_vcn_aoi.py tests/test_vlm_bcq.py -q` |
+| Logging changes | `pytest tests/test_dual_logging.py -q` |
+| Dataset loading helpers | `pytest tests/test_dataset_loading.py -q` |
 
-`ci/run_functional_tests.py` runs `pytest tests -v --color=yes`. Use it when a
-change spans multiple domains and the environment has the needed dependencies.
+There is no `conftest.py` or pytest configuration file. Two skip conventions
+matter:
+
+* GPU- and data-heavy tests (`test_data_analytics.py`, `test_augment.py`) skip
+  themselves when `CI_PROJECT_DIR` is set, a GitLab-era guard that GitHub
+  Actions does not set. They need the private scratch datasets mounted.
+* Some analytics tests skip unless `WANDB_API_KEY` is set.
+
+A few tests stub or skip `nvidia_tao_core` imports; initialize the submodules
+before running the full suite.
 
 ## Common Failures
 
-| Symptom | Likely Cause | Where To Check |
+| Symptom | Likely cause | Where to check |
 | :--- | :--- | :--- |
-| `Experiment spec file was not found` | Standard entrypoint was called without a valid `-e` path. | `nvidia_tao_ds/core/entrypoint/entrypoint.py` |
-| Hydra cannot find a config | The script `config_name` does not match the YAML name or config path. | The target `scripts/*.py` `@hydra_runner(...)` |
-| `nvidia-smi` assertion failure | Requested `num_gpus` exceeds visible GPUs. | `launch()` GPU override logic and spec `gpu_ids` |
-| Docker pull or inspect fails | Local tag is missing or `docker/manifest.json` digest is stale/inaccessible. | `runner/tao_ds.py`, `docker/manifest.json` |
-| Default spec generation rejects a module | Config package shape is not supported by `default_specs.py`. | `nvidia_tao_ds/core/utils/default_specs.py` |
-| API action missing | Installed console scripts or `tao-core` module mappings do not expose it. | `setup.py`, `tao-core/nvidia_tao_core/api_utils/module_utils.py` |
-| W&B tests skip | `WANDB_API_KEY` is not set. | `tests/test_data_analytics.py` |
+| `Experiment spec file was not found` | The standard entry point ran without a valid `-e` path. | `nvidia_tao_ds/core/entrypoint/entrypoint.py` |
+| Hydra cannot find a config | The script `config_name` does not match the YAML name or config path. | The target `scripts/*.py` `@hydra_runner(...)`; for example, `augmentation generate` defaults to `kitti.yaml` |
+| `nvidia-smi` assertion failure | Requested `num_gpus` exceeds visible GPUs, or the host has no GPU (the launcher calls `nvidia-smi` unconditionally, even for CPU subtasks). | `launch()` GPU logic in the shared entrypoint |
+| Command reports FAIL despite exit 0 | The launcher also reads the last record of `results_dir/status.json`. | `_status_reports_failure` in the shared entrypoint |
+| New GPU subtask runs on one GPU only | Multi-GPU parsing is keyed on the subtask name `generate`. | `launch(multigpu_support=...)` |
+| Import errors for `nvidia_tao_core` / `nvidia_tao_pytorch` | Uninitialized submodules. | `git submodule update --init`; in containers `envsetup.sh` sets `PYTHONPATH` |
+| `default_specs` rejects a module | Only flat services are supported; mining and RCCA are not. | `nvidia_tao_ds/core/utils/default_specs.py` |
+| Docker pull or inspect fails | Local tag missing or `docker/manifest.json` digest stale/inaccessible. | `runner/tao_ds.py`, `docker/manifest.json` |
+| Video write fails or codec missing | The base image enforces an LGPL codec allow-list (VP9/mjpeg encode only). | `docker/Dockerfile`, `core/utils/video_utils.py` |
+| API action missing | Installed console scripts or tao-core module mappings do not expose it. | `setup.py`, tao-core `api_utils.module_utils` |
+| Weights and Biases tests skip | `WANDB_API_KEY` is not set. | `tests/test_data_analytics.py` |
 
 ## Debugging Runtime Commands
 
-Print the Docker command without hiding what will run:
+Run a command through the launcher:
 
 ```sh
-tao_ds --gpus all --volume "$PWD:/workspace" -- annotations convert -e nvidia_tao_ds/annotations/experiment_specs/annotations.yaml
+tao_ds --gpus all -- annotations convert -e nvidia_tao_ds/annotations/experiment_specs/annotations.yaml
 ```
 
-For standard entrypoints, command-line Hydra overrides follow the experiment
-spec. For mining and RCCA direct dispatchers, pass Hydra args directly to the
-subtask script through the dispatcher.
+The shared entrypoint launches each subtask as a fresh Python subprocess, so
+breakpoints set in a `scripts/*.py` are never hit through the console command.
+Debug in-process by running the script directly:
+
+```sh
+python nvidia_tao_ds/<service>/scripts/<subtask>.py \
+  --config-path /abs/path/to/spec/dir --config-name <spec_name>
+```
+
+Command-line Hydra overrides follow the experiment specification, for example,
+`results_dir=/results data.input_format=COCO`.

--- a/docs/testing_and_debugging.md
+++ b/docs/testing_and_debugging.md
@@ -48,6 +48,38 @@ rg -n "TBD|PLACEHOLDER|example\\.com" README.md docs
 GPU, Docker build, private checkpoint, NGC, and full dataset tests are outside
 the normal blast radius for documentation-only changes.
 
+## Test Environment Setup
+
+The base development image has pytest and the runtime dependencies
+(`docker/requirements-pip.txt`), but **not** the TAO packages themselves. Set
+up once per container:
+
+```sh
+# On the host
+git submodule update --init          # tao-core/ and tao-pytorch/ are empty otherwise
+source scripts/envsetup.sh
+tao_ds --gpus all -- bash
+
+# Inside the container (repository is mounted at /workspace)
+pip install /workspace/tao-core/.    # provides nvidia_tao_core (status callbacks, api_utils)
+export PYTHONPATH=/workspace/tao-pytorch:$PYTHONPATH   # for tests that import nvidia_tao_pytorch
+pytest tests/test_config_modules.py -q                 # smoke check
+```
+
+Notes:
+
+* `nvidia_tao_core` is not in `docker/requirements-pip.txt` (only its
+  transitive dependencies are), so tests fail with import errors until you
+  install the submodule. This is the step the README historically missed.
+* `nvidia_tao_ds` itself is importable because the launcher sets
+  `PYTHONPATH=/workspace`; run `python setup.py develop` instead if you need
+  the console commands.
+* Tests that exercise Grounding DINO or TAO CLIP (`test_text2box.py`,
+  `tests/mining/test_image_embeddings.py`) import `nvidia_tao_pytorch` from
+  the submodule; the mining tests fall back to stubs when it is absent.
+* GPU- and data-heavy tests additionally need the private scratch datasets
+  mounted (paths under `/media/scratch_metropolis2/tao_ci/...`).
+
 ## Targeted Pytest Map
 
 | Change area | Suggested tests |

--- a/docs/testing_and_debugging.md
+++ b/docs/testing_and_debugging.md
@@ -120,7 +120,7 @@ before running the full suite.
 | Command reports FAIL despite exit 0 | The launcher also reads the last record of `results_dir/status.json`. | `_status_reports_failure` in the shared entrypoint |
 | New GPU subtask runs on one GPU only | Multi-GPU parsing is keyed on the subtask name `generate`. | `launch(multigpu_support=...)` |
 | Import errors for `nvidia_tao_core` / `nvidia_tao_pytorch` | Uninitialized submodules. | `git submodule update --init`; in containers `envsetup.sh` sets `PYTHONPATH` |
-| `default_specs` rejects a module | Only flat services are supported; mining and RCCA are not. | `nvidia_tao_ds/core/utils/default_specs.py` |
+| `default_specs` rejects a module | Only flat functions are supported; mining and RCCA are not. | `nvidia_tao_ds/core/utils/default_specs.py` |
 | Docker pull or inspect fails | Local tag missing or `docker/manifest.json` digest stale/inaccessible. | `runner/tao_ds.py`, `docker/manifest.json` |
 | Video write fails or codec missing | The base image enforces an LGPL codec allow-list (VP9/mjpeg encode only). | `docker/Dockerfile`, `core/utils/video_utils.py` |
 | API action missing | Installed console scripts or tao-core module mappings do not expose it. | `setup.py`, tao-core `api_utils.module_utils` |
@@ -139,7 +139,7 @@ breakpoints set in a `scripts/*.py` are never hit through the console command.
 Debug in-process by running the script directly:
 
 ```sh
-python nvidia_tao_ds/<service>/scripts/<subtask>.py \
+python nvidia_tao_ds/<function>/scripts/<subtask>.py \
   --config-path /abs/path/to/spec/dir --config-name <spec_name>
 ```
 

--- a/tools/update_readme_supported_commands.py
+++ b/tools/update_readme_supported_commands.py
@@ -184,11 +184,11 @@ def render_generated_section(repo_root: Path) -> str:
             "",
             "### Base Image Source",
             "",
-            f"`runner/tao_ds.py` and `ci/utils.py` resolve the immutable base image",
+            f"`runner/tao_ds.py` resolves the immutable base image",
             f"(`{repository}`) from `docker/manifest.json`, choosing the architecture-specific",
             "digest for the host. The pinned digests are intentionally not duplicated here — they",
-            "live in `docker/manifest.json` (and the CI / Jenkins / release files), and a static CI",
-            "check (`ci/run_static_tests.py`) verifies those digest references stay in sync.",
+            "live in `docker/manifest.json` and `release/docker/Dockerfile.release`; update both",
+            "together when the base image is rebuilt.",
         ]
     )
     lines.append(END)


### PR DESCRIPTION
Brings the tao-data-services developer docs to parity with tao-pytorch's docs tree and addresses feedback that the repo structure, modules, and architecture are hard for new developers to pick up.

**What changed**
- **New `docs/codebase_tour.md`** — annotated repo tree, module map, service + auto-label backend inventory, anatomy of the `annotations` service, the two config conventions, and a consolidated sharp-edges list (analytics naming, `default_specs` limits, unconditional `nvidia-smi`, multi-GPU keyed on `generate`, `monitor_status` coverage, codec policy, the two API stories).
- **Expanded `docs/architecture.md`** — shared launcher behavior, configuration flow and field factories, a models-and-weights table (Grounding DINO / MAL / VLM / CLIP), the dev-mode vs production API distinction, and tao-core / tao-pytorch submodule boundaries.
- **Two new diagrams** (`config_flow.svg`, `module_map.svg`) in tao-pytorch's diagram style.
- **GitHub-era CI corrections**: removed stale `.gitlab-ci.yml` / `ci/` / Jenkinsfile references, documented the pre-commit + GitHub Actions checks that actually run, fixed the targeted pytest map to reference only tests that exist, and corrected the digest bump locations.
- **Fixed the generated-README template** in `tools/update_readme_supported_commands.py` (it referenced `ci/run_static_tests.py` and `ci/utils.py`, which no longer exist) and regenerated `README.md`.

**Verification**
- Every path, subtask list, and launcher behavior cross-checked against source at origin/main.
- `python tools/update_readme_supported_commands.py --check` passes; `py_compile` on the tool passes; `git diff --check` clean; SVGs valid; all relative doc links resolve.
- No runtime code touched beyond the README-generator template text.

JIRA: [TAO-2523](https://jirasw.nvidia.com/browse/TAO-2523)