### PR TITLE
fix(security): upgrade urllib3 for 7.2.0 OSS scan

### DIFF
--- a/release/docker/Dockerfile.release
+++ b/release/docker/Dockerfile.release
@@ -76,7 +76,8 @@ RUN cd tao-core && pip install --upgrade pip setuptools wheel && python setup.py
 # nvidia_tao_ds, tao-core, or tao-pytorch Python sources, but the package is still
 # present in the image and flagged by the scanner.
 #   - pydicom 3.0.1 -> 3.0.2 (GHSA-v856-2rf8-9f28 — High)
-RUN PIP_CONSTRAINT="" python -m pip install --upgrade "pydicom>=3.0.2"
+#   - urllib3 2.6.3 -> 2.7.0 (CVE-2026-44431, CVE-2026-44432 — High; no prior pin)
+RUN PIP_CONSTRAINT="" python -m pip install --upgrade "pydicom>=3.0.2" "urllib3>=2.7.0"
 # Note: the ffmpeg-in-opencv Critical fix AND the AWS CLI v2 Python Critical fix have
 # been moved to docker/Dockerfile (base image) so both base and release scans are clean.
 # See base Dockerfile for the rm and aws/install blocks.


### PR DESCRIPTION
## Summary
Upgrade urllib3 flagged by the nSpect/NGC OSS scan for **TAO 7.2.0** (image `7.2.0-data-services`), added to the existing post-tao-core security-upgrade RUN.

| Package | From | To | Advisory |
|---|---|---|---|
| urllib3 | 2.6.3 | ≥2.7.0 | CVE-2026-44431, CVE-2026-44432 (High) |

This was the only OSS blocker on `7.2.0-data-services` not dispositioned as not-reachable (VEX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)